### PR TITLE
Add beta badge to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/digitaledsafety/bedrock-server-manager/actions/workflows/main.yml/badge.svg)](https://github.com/digitaledsafety/bedrock-server-manager/actions/workflows/main.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![Status: Beta](https://img.shields.io/badge/status-beta-orange.svg)
 
 This application provides a web-based interface to manage a single Minecraft Bedrock Dedicated Server. You can start, stop, and restart your server, manage updates, tweak server properties (`server.properties`), manage worlds, and configure automatic updates. The interface is designed to be mobile-friendly.
 

--- a/public/style.css
+++ b/public/style.css
@@ -91,6 +91,17 @@ button:disabled {
     background-color: #FF5555; /* Bright red */
     color: #1E1E1E; /* Dark text */
 }
+.badge-beta {
+    background-color: #FFAA00; /* Gold/Orange */
+    color: #1E1E1E;
+    padding: 2px 8px;
+    border: 2px solid #1E1E1E;
+    font-size: 0.8rem;
+    vertical-align: middle;
+    margin-left: 10px;
+    text-shadow: none;
+    display: inline-block;
+}
 .form-group {
     margin-bottom: 15px;
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -10,7 +10,7 @@
     <div class="container">
         <h1>
             <img src="/favicon.ico" alt="Minecraft Grass Block" style="vertical-align: middle; margin-right: 10px; image-rendering: pixelated;">
-            Bedrock Server Manager
+            Bedrock Server Manager <span class="badge-beta">BETA</span>
         </h1>
 
         <% if (config && config.serverName) { %>


### PR DESCRIPTION
This change adds a "beta" status indicator to the project. It includes a badge in the README.md file and a visually consistent "BETA" badge in the web application's header. The UI badge is styled to match the Minecraft aesthetic of the application.

---
*PR created automatically by Jules for task [18364060987849276021](https://jules.google.com/task/18364060987849276021) started by @brettfxio*