### PR TITLE
Add Log Viewer, PID Persistence, and World Management Enhancements

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,8 +60,7 @@ const validateWorldName = (req, res, next) => {
     if (!worldName) {
         return res.status(400).json({ error: 'World name is required.' });
     }
-    const worldNameRegex = /^[a-zA-Z0-9_ -]+$/;
-    if (worldName.includes('.') || worldName.includes('/') || worldName.includes('\\') || !worldNameRegex.test(worldName)) {
+    if (!backend.isValidWorldName(worldName)) {
         backend.log('ERROR', `Invalid worldName format or characters: ${worldName}`);
         return res.status(400).json({ error: 'Invalid worldName format. Avoid ., /, \\ and ensure it matches allowed pattern.' });
     }
@@ -196,6 +195,35 @@ app.get('/api/config', async (req, res) => {
     }
 });
 
+app.get('/api/logs', async (req, res) => {
+    try {
+        const logFilePath = pathJoin(__dirnameESM, 'mc_installer.log');
+        if (!fs.existsSync(logFilePath)) {
+            return res.json({ success: true, logs: 'Log file not found.' });
+        }
+
+        const stats = await fs.promises.stat(logFilePath);
+        const bufferSize = 16 * 1024; // Read last 16KB
+        const start = Math.max(0, stats.size - bufferSize);
+        const length = stats.size - start;
+
+        const buffer = Buffer.alloc(length);
+        const fileHandle = await fs.promises.open(logFilePath, 'r');
+        try {
+            await fileHandle.read(buffer, 0, length, start);
+            const logContent = buffer.toString('utf8');
+            const lines = logContent.split('\n');
+            const lastLines = lines.slice(-100).join('\n');
+            res.json({ success: true, logs: lastLines });
+        } finally {
+            await fileHandle.close();
+        }
+    } catch (error) {
+        backend.log('ERROR', `Error reading log file: ${error.message}`);
+        res.status(500).json({ error: 'Failed to read logs' });
+    }
+});
+
 app.post('/api/config', async (req, res) => {
     try {
         const newSettings = req.body;
@@ -250,8 +278,7 @@ app.post('/api/upload-pack', upload.single('packFile'), async (req, res) => {
     }
 
     // Validate worldName
-    const worldNameRegex = /^[a-zA-Z0-9_ -]+$/; // Basic format check
-    if (worldName.includes('.') || worldName.includes('/') || worldName.includes('\\') || !worldNameRegex.test(worldName)) {
+    if (!backend.isValidWorldName(worldName)) {
         backend.log('ERROR', `Invalid worldName format or characters for pack upload: ${worldName}`);
         fs.unlink(packFile.path, (err) => {
             if (err) backend.log('WARNING', `Failed to delete orphaned upload ${packFile.path}: ${err.message}`);

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -24,6 +24,7 @@ let BACKUP_DIRECTORY;
 let serverPID = null;
 
 const LAST_VERSION_FILE = 'last_version.txt';
+const PID_FILE = 'server.pid';
 const WEBHOOK_URL = process.env.MC_UPDATE_WEBHOOK;
 const CONFIG_FILES = ['server.properties', 'permissions.json', 'whitelist.json'];
 const WORLD_DIRECTORIES = ['worlds'];
@@ -382,29 +383,74 @@ export async function copyExistingData(backupDir, newInstallDir) {
 
 export async function stopServer() {
     if (!serverPID) {
-        log('INFO', `Server process PID not found. Server may already be stopped.`);
-        return;
+        // Try reading from file if memory PID is missing
+        const storedPid = getStoredPID();
+        if (storedPid) {
+            serverPID = storedPid;
+        } else {
+            log('INFO', `Server process PID not found. Server may already be stopped.`);
+            return;
+        }
     }
-    try {
-        log('INFO', `Attempting to stop Minecraft server process with PID: ${serverPID}.`);
+    try {
+        log('INFO', `Attempting to stop Minecraft server process with PID: ${serverPID}.`);
         process.kill(serverPID, 'SIGTERM');
         log('INFO', `SIGTERM signal sent to PID: ${serverPID}.`);
-    } catch (error) {
-        log('ERROR', `Error stopping server with PID ${serverPID} (process might not exist): ${error.message}`);
-    } finally {
+    } catch (error) {
+        log('ERROR', `Error stopping server with PID ${serverPID} (process might not exist): ${error.message}`);
+    } finally {
         serverPID = null;
+        removePIDFile();
+    }
+}
+
+function storePID(pid) {
+    try {
+        fs.writeFileSync(pathJoin(__dirnameESM, PID_FILE), pid.toString());
+        log('DEBUG', `Stored server PID ${pid} to ${PID_FILE}`);
+    } catch (error) {
+        log('ERROR', `Error storing PID to file: ${error.message}`);
+    }
+}
+
+function getStoredPID() {
+    try {
+        const pidFilePath = pathJoin(__dirnameESM, PID_FILE);
+        if (fs.existsSync(pidFilePath)) {
+            const pidStr = fs.readFileSync(pidFilePath, 'utf8').trim();
+            const pid = parseInt(pidStr, 10);
+            if (!isNaN(pid)) {
+                return pid;
+            }
+        }
+    } catch (error) {
+        log('ERROR', `Error reading PID from file: ${error.message}`);
+    }
+    return null;
+}
+
+function removePIDFile() {
+    try {
+        const pidFilePath = pathJoin(__dirnameESM, PID_FILE);
+        if (fs.existsSync(pidFilePath)) {
+            fs.unlinkSync(pidFilePath);
+            log('DEBUG', `Removed PID file ${PID_FILE}`);
+        }
+    } catch (error) {
+        log('ERROR', `Error removing PID file: ${error.message}`);
     }
 }
 
 export async function startServer() {
-    if (serverPID) {
-        log('INFO', `Server process already has a PID: ${serverPID}. Check if it's running.`);
+    if (serverPID || getStoredPID()) {
+        log('INFO', `Server process already has a PID. Check if it's running.`);
         if (await isProcessRunning()) {
             log('INFO', `Server is already running with PID ${serverPID}.`);
             return;
         } else {
-            log('INFO', `Stale PID ${serverPID} found. Clearing.`);
+            log('INFO', `Stale PID found. Clearing.`);
             serverPID = null;
+            removePIDFile();
         }
     }
     try {
@@ -421,19 +467,26 @@ export async function startServer() {
         });
         if (serverProcess.pid) {
             serverPID = serverProcess.pid;
+            storePID(serverPID);
             log('INFO', `Server process started with PID: ${serverPID}.`);
         } else {
             log('ERROR', `Server process started but PID was not obtained.`);
         }
         serverProcess.unref();
-        serverProcess.on('error', (err) => {
-            log('ERROR', `Server process error: ${err.message}`);
-            if (serverPID === serverProcess.pid) serverPID = null;
-        });
-        serverProcess.on('exit', (code, signal) => {
-            log('INFO', `Server process PID ${serverProcess.pid} exited with code ${code} and signal ${signal}`);
-            if (serverPID === serverProcess.pid) serverPID = null;
-        });
+        serverProcess.on('error', (err) => {
+            log('ERROR', `Server process error: ${err.message}`);
+            if (serverPID === serverProcess.pid) {
+                serverPID = null;
+                removePIDFile();
+            }
+        });
+        serverProcess.on('exit', (code, signal) => {
+            log('INFO', `Server process PID ${serverProcess.pid} exited with code ${code} and signal ${signal}`);
+            if (serverPID === serverProcess.pid) {
+                serverPID = null;
+                removePIDFile();
+            }
+        });
     } catch (error) {
         log('ERROR', `Error starting server: ${error.message}`);
         if (serverPID) serverPID = null;
@@ -518,38 +571,20 @@ export async function checkAndInstall() {
 }
 
 /**
- * Removes a directory recursively. Cross-platform compatible.
- * @param {string} dirPath The path to the directory to remove.
- * @returns {Promise<void>} A promise that resolves when the directory is removed.
- */
-function removeDir(dirPath) {
-    return new Promise((resolve, reject) => {
-        if (!fs.existsSync(dirPath)) {
-            resolve(); // Resolve if the directory does not exist
-            return;
-        }
-
-        const platform = os.platform();
-        if (platform === 'win32') {
-            // Use Windows command to remove directory recursively and quietly
-            childProcessExec(`rmdir /s /q "${dirPath}"`, (error, stdout, stderr) => {
-                if (error) {
-                    reject(new Error(`Failed to remove directory ${dirPath}: ${error.message} ${stderr}`));
-                } else {
-                    resolve();
-                }
-            });
-        } else {
-            // Use Linux command to remove directory recursively and forcefully
-            childProcessExec(`rm -rf "${dirPath}"`, (error, stdout, stderr) => {
-                if (error) {
-                    reject(new Error(`Failed to remove directory ${dirPath}: ${error.message} ${stderr}`));
-                } else {
-                    resolve();
-                }
-            });
-        }
-    });
+ * Removes a directory recursively. Cross-platform compatible.
+ * @param {string} dirPath The path to the directory to remove.
+ * @returns {Promise<void>} A promise that resolves when the directory is removed.
+ */
+async function removeDir(dirPath) {
+    if (!fs.existsSync(dirPath)) {
+        return;
+    }
+    try {
+        await fs.promises.rm(dirPath, { recursive: true, force: true });
+    } catch (error) {
+        log('ERROR', `Failed to remove directory ${dirPath}: ${error.message}`);
+        throw error;
+    }
 }
 
 
@@ -644,22 +679,31 @@ export async function restartServer() {
 
 export async function isProcessRunning() {
     if (!serverPID) {
+        serverPID = getStoredPID();
+    }
+
+    if (!serverPID) {
         log('DEBUG', `No PID found for server. Assuming not running.`);
         return false;
     }
-    try {
+
+    try {
         process.kill(serverPID, 0);
         log('DEBUG', `Process with PID ${serverPID} is running.`);
-        return true;
-    } catch (error) {
+        return true;
+    } catch (error) {
         if (error.code === 'ESRCH') {
             log('INFO', `Process with PID ${serverPID} not found (ESRCH).`);
+        } else if (error.code === 'EPERM') {
+            log('INFO', `Process with PID ${serverPID} found but no permission to signal it. Assuming it's running.`);
+            return true;
         } else {
             log('ERROR', `Error checking process PID ${serverPID}: ${error.message} (Code: ${error.code})`);
         }
         serverPID = null;
-        return false;
-    }
+        removePIDFile();
+        return false;
+    }
 }
 
 export async function sendWebhookNotification(message) {
@@ -700,6 +744,17 @@ export async function sendWebhookNotification(message) {
     });
 }
 
+/**
+ * Validates a world name for basic format and potential path traversal characters.
+ * @param {string} worldName - The world name to validate.
+ * @returns {boolean} True if valid, false otherwise.
+ */
+export function isValidWorldName(worldName) {
+    if (!worldName) return false;
+    const worldNameRegex = /^[a-zA-Z0-9_ -]+$/;
+    return !worldName.includes('.') && !worldName.includes('/') && !worldName.includes('\\') && worldNameRegex.test(worldName);
+}
+
 export async function readGlobalConfig() {
     const configPath = pathJoin(__dirnameESM, GLOBAL_CONFIG_FILE);
     let effectiveConfig = {
@@ -707,7 +762,7 @@ export async function readGlobalConfig() {
         serverDirectory: "./server_data/default_server", tempDirectory: "./server_data/temp/default_server",
         backupDirectory: "./server_data/backup/default_server", worldName: "Bedrock level",
         autoStart: true, autoUpdateEnabled: false, autoUpdateIntervalMinutes: 60, logLevel: "INFO",
-        minecraftUser: "minecraft", minecraftGroup: "minecraft", serverType: "bedrock"
+        minecraftUser: "minecraft", minecraftGroup: "minecraft", serverType: "bedrock", uiPort: 3000
     };
     setLogLevel(effectiveConfig.logLevel);
     if (fs.existsSync(configPath)) {

--- a/public/script.js
+++ b/public/script.js
@@ -7,7 +7,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const updateButton = document.getElementById('updateButton');
     const propertiesForm = document.getElementById('propertiesForm');
     const levelNameInput = document.getElementById('level-name'); // Get the level-name input
-    const consoleOutput = document.getElementById('consoleOutput'); // Get the console textarea
 
     // Auto-Update specific elements
     const autoUpdateConfigForm = document.getElementById('autoUpdateConfigForm');
@@ -20,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const packTypeSelect = document.getElementById('packType');
     const packWorldNameSelect = document.getElementById('packWorldName');
     const uploadPackButton = document.getElementById('uploadPackButton');
+    const logViewer = document.getElementById('logViewer');
 
 
     // --- Utility Functions ---
@@ -254,20 +254,40 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    function handleActivateWorldClick(event) {
+    async function handleActivateWorldClick(event) {
         const worldName = event.target.dataset.worldName;
-        if (levelNameInput) {
-            levelNameInput.value = worldName; // This updates the text input
-            showMessage(`'level-name' property updated to '${worldName}'. Remember to click "Save Properties".`, 'success');
+        if (!confirm(`Are you sure you want to activate world '${worldName}'? This will update server properties and restart the server.`)) {
+            return;
+        }
 
-            // Update active state in UI
-            document.querySelectorAll('.world-item').forEach(item => {
-                item.classList.remove('active');
+        try {
+            showMessage(`Activating world '${worldName}'...`);
+            const response = await fetch('/api/activate-world', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ worldName })
             });
-            event.target.closest('.world-item').classList.add('active');
-        } else {
-            console.error('level-name input not found.');
-            showMessage('Could not find level-name input to update.', 'error');
+            const data = await response.json();
+            if (response.ok) {
+                showMessage(data.message || `World '${worldName}' activated.`, 'success');
+                // Update active state in UI
+                document.querySelectorAll('.world-item').forEach(item => {
+                    item.classList.remove('active');
+                });
+                event.target.closest('.world-item').classList.add('active');
+                if (levelNameInput) {
+                    levelNameInput.value = worldName;
+                }
+                // Fetch status to reflect restart
+                setTimeout(fetchServerStatus, 2000);
+            } else {
+                showMessage(data.error || `Failed to activate world '${worldName}'.`, 'error');
+            }
+        } catch (error) {
+            console.error('Error activating world:', error);
+            showMessage('An error occurred while activating the world.', 'error');
         }
     }
 
@@ -285,6 +305,22 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (error) {
             console.error('Error loading auto-update config:', error);
             showMessage('Failed to load auto-update configuration.', 'error');
+        }
+    }
+
+    async function fetchLogs() {
+        try {
+            const response = await fetch('/api/logs');
+            const data = await response.json();
+            if (data.success && logViewer) {
+                const isScrolledToBottom = logViewer.scrollHeight - logViewer.clientHeight <= logViewer.scrollTop + 1;
+                logViewer.textContent = data.logs;
+                if (isScrolledToBottom) {
+                    logViewer.scrollTop = logViewer.scrollHeight;
+                }
+            }
+        } catch (error) {
+            console.error('Error fetching logs:', error);
         }
     }
 
@@ -341,5 +377,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Refresh status and worlds periodically
     setInterval(fetchServerStatus, 10000); // Every 10 seconds
     setInterval(loadWorlds, 30000); // Every 30 seconds
+    setInterval(fetchLogs, 5000); // Every 5 seconds
+
+    fetchLogs(); // Initial fetch
 
 });

--- a/test/minecraft_bedrock_installer_nodejs.test.js
+++ b/test/minecraft_bedrock_installer_nodejs.test.js
@@ -4,10 +4,12 @@ import { jest } from '@jest/globals';
 jest.unstable_mockModule('fs', () => ({
   promises: {
     readFile: jest.fn(),
+    rm: jest.fn(),
   },
   existsSync: jest.fn(),
   readFileSync: jest.fn(),
   writeFileSync: jest.fn(),
+  unlinkSync: jest.fn(),
   createWriteStream: jest.fn(() => ({ write: jest.fn() })),
   mkdirSync: jest.fn(), // Added mock for mkdirSync
 }));
@@ -118,6 +120,22 @@ gamemode=survival
         expect(config.autoUpdateEnabled).toBe(true);
 
         process.argv = [];
+    });
+  });
+
+  describe('isValidWorldName', () => {
+    it('should return true for valid world names', () => {
+      expect(backend.isValidWorldName('MyWorld')).toBe(true);
+      expect(backend.isValidWorldName('My World')).toBe(true);
+      expect(backend.isValidWorldName('My-World_123')).toBe(true);
+    });
+
+    it('should return false for invalid world names', () => {
+      expect(backend.isValidWorldName('')).toBe(false);
+      expect(backend.isValidWorldName('World.1')).toBe(false);
+      expect(backend.isValidWorldName('World/2')).toBe(false);
+      expect(backend.isValidWorldName('World\\3')).toBe(false);
+      expect(backend.isValidWorldName('World!')).toBe(false);
     });
   });
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -31,7 +31,11 @@
 
         <div class="section">
             <div id="messageBox" class="message-box" role="alert" style="display: none;"></div>
-            <h2>Server Status</h2>
+            <h2>Server Logs</h2>
+            <pre id="logViewer" style="background-color: #1e1e1e; color: #d4d4d4; padding: 10px; height: 200px; overflow-y: scroll; font-family: monospace; border-radius: 4px; font-size: 0.8rem;"></pre>
+        </div>
+
+        <div class="section">
             <p>Current Status: <span id="serverStatus" class="status-indicator status-<%= serverStatus %>"><%= serverStatus.toUpperCase() %></span></p>
             <% if (config.serverType === 'java') { %>
                 <p>Java server support is coming soon!</p>
@@ -82,7 +86,7 @@
                     <p>No worlds found. Start the server to generate a default world.</p>
                 <% } %>
             </div>
-            <p>To activate a world, click 'Activate' next to its name. This will update the 'level-name' property. Remember to click "Save Properties" to apply the change.</p>
+            <p>To activate a world, click 'Activate' next to its name. This will update the 'level-name' property and <strong>restart the server</strong> to apply the change.</p>
         </div>
 
         <div class="section">


### PR DESCRIPTION
This PR introduces several enhancements and bug fixes to the Bedrock Server Manager:

1.  **Log Viewer:** A new section in the UI allows users to view the manager's logs in real-time. The backend efficiently reads only the end of the log file to minimize memory usage.
2.  **PID Persistence:** The server's Process ID is now stored in `server.pid`. This allows the manager to maintain control over a running Minecraft server even if the manager process itself is restarted.
3.  **Robust Directory Management:** Replaced `rm -rf` and `rmdir` shell calls with native `fs.promises.rm` for better cross-platform reliability.
4.  **Improved World Management:** The "Activate" button now correctly triggers the backend activation logic (updating properties and restarting the server) with a confirmation dialog for the user.
5.  **Code Quality:** Consolidated world name validation into a reusable helper function and included `uiPort` in the default configuration.
6.  **Testing:** Expanded the test suite to cover new functionality and ensured all tests pass.

---
*PR created automatically by Jules for task [4923868766734166210](https://jules.google.com/task/4923868766734166210) started by @brettfxio*