### PR TITLE
Add support for bedrock_server_preview server type

### DIFF
--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -167,7 +167,12 @@ export async function getLatestVersion() {
             res.on('end', () => {
                 try {
                     const jsonResponse = JSON.parse(data);
-                    const targetDownloadType = platform === 'win32' ? 'serverBedrockWindows' : 'serverBedrockLinux';
+                    let targetDownloadType;
+                    if (serverType === 'bedrock_server_preview') {
+                        targetDownloadType = platform === 'win32' ? 'serverBedrockPreviewWindows' : 'serverBedrockPreviewLinux';
+                    } else {
+                        targetDownloadType = platform === 'win32' ? 'serverBedrockWindows' : 'serverBedrockLinux';
+                    }
                     let foundLink = null;
                     if (jsonResponse && jsonResponse.result && jsonResponse.result.links) {
                         foundLink = jsonResponse.result.links.find(link => link.downloadType === targetDownloadType);

--- a/test/preview_support.test.js
+++ b/test/preview_support.test.js
@@ -1,0 +1,118 @@
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+// Mocking https, fs, and os before importing the backend
+jest.unstable_mockModule('https', () => ({
+  default: {
+    get: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule('fs', () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  createWriteStream: jest.fn(() => ({
+    write: jest.fn(),
+    on: jest.fn(),
+    close: jest.fn(),
+  })),
+  writeFileSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
+jest.unstable_mockModule('os', () => ({
+  default: {
+    platform: jest.fn(),
+  },
+}));
+
+// Import modules after mocks are defined
+const https = (await import('https')).default;
+const os = (await import('os')).default;
+const backend = await import('../minecraft_bedrock_installer_nodejs.js');
+
+describe('Preview Server Support', () => {
+  let consoleLogSpy;
+
+  beforeAll(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should correctly select the preview download URL for Windows', async () => {
+    os.platform.mockReturnValue('win32');
+    backend.init({ serverType: 'bedrock_server_preview', logLevel: 'DEBUG' });
+
+    const mockApiResponse = {
+      result: {
+        links: [
+          { downloadType: 'serverBedrockWindows', downloadUrl: 'https://example.com/bedrock-server-1.20.0.1.zip' },
+          { downloadType: 'serverBedrockPreviewWindows', downloadUrl: 'https://example.com/bedrock-server-1.21.0.2.zip' },
+        ],
+      },
+    };
+
+    const mockResponse = new EventEmitter();
+    mockResponse.statusCode = 200;
+
+    https.get.mockImplementation((url, options, callback) => {
+        if (typeof options === 'function') {
+            callback = options;
+        }
+
+        callback(mockResponse);
+        mockResponse.emit('data', JSON.stringify(mockApiResponse));
+        mockResponse.emit('end');
+        return new EventEmitter();
+    });
+
+    const result = await backend.getLatestVersion();
+
+    expect(result).toEqual({
+      latestVersion: '1.21.0.2',
+      downloadUrl: 'https://example.com/bedrock-server-1.21.0.2.zip',
+    });
+  });
+
+  it('should correctly select the preview download URL for Linux', async () => {
+    os.platform.mockReturnValue('linux');
+    backend.init({ serverType: 'bedrock_server_preview', logLevel: 'DEBUG' });
+
+    const mockApiResponse = {
+      result: {
+        links: [
+          { downloadType: 'serverBedrockLinux', downloadUrl: 'https://example.com/bedrock-server-1.20.0.1.zip' },
+          { downloadType: 'serverBedrockPreviewLinux', downloadUrl: 'https://example.com/bedrock-server-1.21.0.2.zip' },
+        ],
+      },
+    };
+
+    const mockResponse = new EventEmitter();
+    mockResponse.statusCode = 200;
+
+    https.get.mockImplementation((url, options, callback) => {
+        if (typeof options === 'function') {
+            callback = options;
+        }
+
+        callback(mockResponse);
+        mockResponse.emit('data', JSON.stringify(mockApiResponse));
+        mockResponse.emit('end');
+        return new EventEmitter();
+    });
+
+    const result = await backend.getLatestVersion();
+
+    expect(result).toEqual({
+      latestVersion: '1.21.0.2',
+      downloadUrl: 'https://example.com/bedrock-server-1.21.0.2.zip',
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for a new "bedrock_server_preview" server type. When this type is configured in config.json, the application will download and manage the preview versions of the Minecraft Bedrock server for both Windows and Linux, using the appropriate download types from the Minecraft download API. Comprehensive tests have been added to ensure the correct download links are selected for each platform.

---
*PR created automatically by Jules for task [13736461224907935490](https://jules.google.com/task/13736461224907935490) started by @brettfxio*