### PR TITLE
Improve Reliability and Add Features to Bedrock Server Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node-v22.14.0-win-x64/
 server_data/
 config.json
 temp_uploads/
+server.pid

--- a/app.js
+++ b/app.js
@@ -130,6 +130,20 @@ app.post('/api/restart', async (req, res) => {
     }
 });
 
+app.post('/api/backup', async (req, res) => {
+    try {
+        const backupPath = await backend.backupServer();
+        if (backupPath) {
+            res.json({ success: true, message: `Backup created at: ${backupPath}` });
+        } else {
+            res.status(500).json({ error: 'Failed to create backup.' });
+        }
+    } catch (error) {
+        backend.log('ERROR', `Failed to create manual backup: ${error.message}`);
+        res.status(500).json({ error: 'Failed to create backup' });
+    }
+});
+
 app.post('/api/update', async (req, res) => {
     try {
         const result = await backend.checkAndInstall();
@@ -193,6 +207,36 @@ app.get('/api/config', async (req, res) => {
     } catch (error) {
         backend.log('ERROR', `Error getting application config: ${error.message}`);
         res.status(500).json({ error: 'Failed to get application config' });
+    }
+});
+
+app.get('/api/logs', async (req, res) => {
+    try {
+        const logFilePath = pathJoin(__dirnameESM, 'mc_installer.log');
+        if (!fs.existsSync(logFilePath)) {
+            return res.json({ success: true, logs: 'Log file not found.' });
+        }
+
+        const MAX_LINES = 50;
+        const stats = await fs.promises.stat(logFilePath);
+        const fileSize = stats.size;
+        // Read at most last 16KB, should be enough for 50 lines
+        const bufferSize = Math.min(fileSize, 16384);
+        const buffer = Buffer.alloc(bufferSize);
+        const fileHandle = await fs.promises.open(logFilePath, 'r');
+
+        try {
+            await fileHandle.read(buffer, 0, bufferSize, fileSize - bufferSize);
+            const content = buffer.toString('utf8');
+            const lines = content.split('\n');
+            const lastLines = lines.slice(-(MAX_LINES + 1)).join('\n');
+            res.json({ success: true, logs: lastLines });
+        } finally {
+            await fileHandle.close();
+        }
+    } catch (error) {
+        backend.log('ERROR', `Error reading logs: ${error.message}`);
+        res.status(500).json({ error: 'Failed to read logs' });
     }
 });
 
@@ -340,7 +384,7 @@ const start = async () => {
         }
         await backend.startAutoUpdateScheduler();
 
-        const port = initialConfig.uiPort ?? PORT;
+        const port = initialConfig.uiPort || PORT;
 
         // This check prevents the server from starting during tests
         if (process.env.NODE_ENV !== 'test') {

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -28,6 +28,7 @@ const WEBHOOK_URL = process.env.MC_UPDATE_WEBHOOK;
 const CONFIG_FILES = ['server.properties', 'permissions.json', 'whitelist.json'];
 const WORLD_DIRECTORIES = ['worlds'];
 const GLOBAL_CONFIG_FILE = 'config.json';
+const PID_FILE = 'server.pid';
 
 let autoUpdateIntervalId = null;
 
@@ -323,7 +324,11 @@ export async function backupServer() {
     try {
         await copyDir(SERVER_DIRECTORY, backupDir);
         if (os.platform() !== 'win32') {
-            await changeOwnership(backupDir, config.minecraftUser, config.minecraftGroup);
+            try {
+                await changeOwnership(backupDir, config.minecraftUser, config.minecraftGroup);
+            } catch (chownError) {
+                log('WARNING', `Failed to change ownership for backup ${backupDir}: ${chownError.message}. Continuing anyway.`);
+            }
         }
         log('INFO', `Backup complete in ${backupDir}`);
         return backupDir;
@@ -387,13 +392,50 @@ export async function copyExistingData(backupDir, newInstallDir) {
 
 export async function stopServer() {
     if (!serverPID) {
+        const pidFilePath = pathJoin(__dirnameESM, PID_FILE);
+        if (fs.existsSync(pidFilePath)) {
+            try {
+                serverPID = parseInt(fs.readFileSync(pidFilePath, 'utf8').trim(), 10);
+                log('INFO', `Retrieved PID ${serverPID} from ${PID_FILE}.`);
+            } catch (error) {
+                log('ERROR', `Failed to read PID from ${PID_FILE}: ${error.message}`);
+            }
+        }
+    }
+
+    if (!serverPID) {
         log('INFO', `Server process PID not found. Server may already be stopped.`);
         return;
     }
+    const pidToKill = serverPID;
     try {
-        log('INFO', `Attempting to stop Minecraft server process with PID: ${serverPID}.`);
-        process.kill(serverPID, 'SIGTERM');
-        log('INFO', `SIGTERM signal sent to PID: ${serverPID}.`);
+        log('INFO', `Attempting to stop Minecraft server process with PID: ${pidToKill}.`);
+        process.kill(pidToKill, 'SIGTERM');
+        log('INFO', `SIGTERM signal sent to PID: ${pidToKill}.`);
+
+        // Polling loop for termination
+        let isStillRunning = true;
+        for (let i = 0; i < 30; i++) {
+            try {
+                process.kill(pidToKill, 0);
+                await new Promise(resolve => setTimeout(resolve, 1000));
+            } catch (e) {
+                isStillRunning = false;
+                break;
+            }
+        }
+
+        if (isStillRunning) {
+            log('WARNING', `Server process with PID ${pidToKill} did not stop after 30 seconds.`);
+        } else {
+            log('INFO', `Server process with PID ${pidToKill} has stopped.`);
+            const pidFilePath = pathJoin(__dirnameESM, PID_FILE);
+            if (fs.existsSync(pidFilePath)) {
+                fs.unlinkSync(pidFilePath);
+                log('INFO', `Removed ${PID_FILE}.`);
+            }
+        }
+
     } catch (error) {
         log('ERROR', `Error stopping server with PID ${serverPID} (process might not exist): ${error.message}`);
     } finally {
@@ -427,6 +469,12 @@ export async function startServer() {
         if (serverProcess.pid) {
             serverPID = serverProcess.pid;
             log('INFO', `Server process started with PID: ${serverPID}.`);
+            try {
+                fs.writeFileSync(pathJoin(__dirnameESM, PID_FILE), serverPID.toString());
+                log('INFO', `Saved PID to ${PID_FILE}.`);
+            } catch (error) {
+                log('ERROR', `Failed to save PID to ${PID_FILE}: ${error.message}`);
+            }
         } else {
             log('ERROR', `Server process started but PID was not obtained.`);
         }
@@ -567,12 +615,16 @@ export async function readServerProperties() {
     const data = await fs.promises.readFile(configPath, 'utf8');
     const properties = {};
     data.split('\n').forEach(line => {
-        const trimmedLine = line.trim();
-        if (trimmedLine && !trimmedLine.startsWith('#')) {
-            const [key, value] = trimmedLine.split('=').map(s => s.trim());
-            if (key) { properties[key] = value || ''; }
-        }
-    });
+        const trimmedLine = line.trim();
+        if (trimmedLine && !trimmedLine.startsWith('#')) {
+            const firstEqualsIndex = trimmedLine.indexOf('=');
+            if (firstEqualsIndex !== -1) {
+                const key = trimmedLine.substring(0, firstEqualsIndex).trim();
+                const value = trimmedLine.substring(firstEqualsIndex + 1).trim();
+                if (key) { properties[key] = value; }
+            }
+        }
+    });
     log('INFO', `Read server.properties from ${configPath}`);
     return properties;
 }
@@ -649,6 +701,18 @@ export async function restartServer() {
 
 export async function isProcessRunning() {
     if (!serverPID) {
+        const pidFilePath = pathJoin(__dirnameESM, PID_FILE);
+        if (fs.existsSync(pidFilePath)) {
+            try {
+                serverPID = parseInt(fs.readFileSync(pidFilePath, 'utf8').trim(), 10);
+                log('INFO', `Retrieved PID ${serverPID} from ${PID_FILE} during status check.`);
+            } catch (error) {
+                log('ERROR', `Failed to read PID from ${PID_FILE}: ${error.message}`);
+            }
+        }
+    }
+
+    if (!serverPID) {
         log('DEBUG', `No PID found for server. Assuming not running.`);
         return false;
     }
@@ -708,7 +772,7 @@ export async function sendWebhookNotification(message) {
 export async function readGlobalConfig() {
     const configPath = pathJoin(__dirnameESM, GLOBAL_CONFIG_FILE);
     let effectiveConfig = {
-        serverName: "Default Minecraft Server", serverPortIPv4: 19132, serverPortIPv6: 19133,
+        serverName: "Default Minecraft Server", serverPortIPv4: 19132, serverPortIPv6: 19133, uiPort: 3000,
         serverDirectory: "./server_data/default_server", tempDirectory: "./server_data/temp/default_server",
         backupDirectory: "./server_data/backup/default_server", worldName: "Bedrock level",
         autoStart: true, autoUpdateEnabled: false, autoUpdateIntervalMinutes: 60, logLevel: "INFO",
@@ -745,6 +809,7 @@ export async function readGlobalConfig() {
             case '--tempDirectory': if(valueConsumed) effectiveConfig.tempDirectory = value; break;
             case '--backupDirectory': if(valueConsumed) effectiveConfig.backupDirectory = value; break;
             case '--worldName': if(valueConsumed) effectiveConfig.worldName = value; break;
+            case '--uiPort': if(valueConsumed) effectiveConfig.uiPort = parseInt(value, 10); break;
             case '--autoStart': effectiveConfig.autoStart = (valueConsumed ? (value === 'true') : true); break;
             case '--autoUpdateEnabled': effectiveConfig.autoUpdateEnabled = (valueConsumed ? (value === 'true') : true); break;
             case '--logLevel': if(valueConsumed) effectiveConfig.logLevel = value.toUpperCase(); break;

--- a/public/script.js
+++ b/public/script.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const stopButton = document.getElementById('stopButton');
     const restartButton = document.getElementById('restartButton');
     const updateButton = document.getElementById('updateButton');
+    const backupButton = document.getElementById('backupButton');
     const propertiesForm = document.getElementById('propertiesForm');
     const levelNameInput = document.getElementById('level-name'); // Get the level-name input
     const consoleOutput = document.getElementById('consoleOutput'); // Get the console textarea
@@ -21,6 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const packTypeGroup = document.getElementById('packTypeGroup');
     const packWorldNameSelect = document.getElementById('packWorldName');
     const uploadPackButton = document.getElementById('uploadPackButton');
+    const logOutput = document.getElementById('logOutput');
+    const refreshLogsButton = document.getElementById('refreshLogsButton');
 
 
     // --- Utility Functions ---
@@ -40,16 +43,19 @@ document.addEventListener('DOMContentLoaded', () => {
             stopButton.disabled = false;
             restartButton.disabled = false;
             updateButton.disabled = false;
+            if (backupButton) backupButton.disabled = false;
         } else if (status === 'stopped') {
             startButton.disabled = false;
             stopButton.disabled = true;
             restartButton.disabled = true;
             updateButton.disabled = false; // Allow update even if server is stopped
+            if (backupButton) backupButton.disabled = false;
         } else { // unknown status
             startButton.disabled = false; // Allow starting if unknown, as it might be stopped
             stopButton.disabled = true;
             restartButton.disabled = true;
             updateButton.disabled = true; // Disable update if status is unknown
+            if (backupButton) backupButton.disabled = true;
         }
     }
 
@@ -144,6 +150,7 @@ document.addEventListener('DOMContentLoaded', () => {
             stopButton.disabled = true;
             restartButton.disabled = true;
             updateButton.disabled = true;
+            if (backupButton) backupButton.disabled = true;
 
             const response = await fetch(`/api/${command}`, { method: 'POST' });
             const data = await response.json();
@@ -287,6 +294,21 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Auto-Update Configuration Functions ---
+    async function fetchLogs() {
+        try {
+            const response = await fetch('/api/logs');
+            const data = await response.json();
+            if (data.success) {
+                logOutput.textContent = data.logs;
+                logOutput.scrollTop = logOutput.scrollHeight;
+            } else {
+                console.error('Failed to fetch logs:', data.error);
+            }
+        } catch (error) {
+            console.error('Error fetching logs:', error);
+        }
+    }
+
     async function loadAutoUpdateConfig() {
         try {
             const response = await fetch('/api/config');
@@ -342,8 +364,10 @@ document.addEventListener('DOMContentLoaded', () => {
     stopButton.addEventListener('click', () => sendCommand('stop'));
     restartButton.addEventListener('click', () => sendCommand('restart'));
     updateButton.addEventListener('click', () => sendCommand('update'));
+    if (backupButton) backupButton.addEventListener('click', () => sendCommand('backup'));
     if (propertiesForm) propertiesForm.addEventListener('submit', saveServerProperties);
     if (autoUpdateConfigForm) autoUpdateConfigForm.addEventListener('submit', saveAutoUpdateConfig);
+    if (refreshLogsButton) refreshLogsButton.addEventListener('click', fetchLogs);
     if (uploadPackForm) {
         uploadPackForm.addEventListener('submit', handleUploadPack);
         packFileInput.addEventListener('change', handlePackFileChange);
@@ -355,9 +379,11 @@ document.addEventListener('DOMContentLoaded', () => {
     //loadServerProperties();
     //loadWorlds();
     loadAutoUpdateConfig(); // New: Load auto-update config on page load
+    fetchLogs();
 
     // Refresh status and worlds periodically
     setInterval(fetchServerStatus, 10000); // Every 10 seconds
     setInterval(loadWorlds, 30000); // Every 30 seconds
+    setInterval(fetchLogs, 15000); // Every 15 seconds
 
 });

--- a/test/minecraft_bedrock_installer_nodejs.test.js
+++ b/test/minecraft_bedrock_installer_nodejs.test.js
@@ -41,6 +41,7 @@ describe('Minecraft Bedrock Installer Backend', () => {
 server-name=My Test Server
 level-seed=12345
 gamemode=survival
+extra-param=value=with=equals
 `;
       fs.existsSync.mockReturnValue(true);
       fs.promises.readFile.mockResolvedValue(mockProperties);
@@ -55,6 +56,7 @@ gamemode=survival
         'server-name': 'My Test Server',
         'level-seed': '12345',
         'gamemode': 'survival',
+        'extra-param': 'value=with=equals'
       });
     });
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -47,6 +47,7 @@
                     <button id="stopButton">Stop Server</button>
                     <button id="restartButton">Restart Server</button>
                     <button id="updateButton">Check & Install Update</button>
+                    <button id="backupButton">Create Backup</button>
                 </div>
             <% } %>
         </div>
@@ -115,6 +116,12 @@
                 </div>
                 <button type="submit" id="uploadPackButton">Upload Pack</button>
             </form>
+        </div>
+
+        <div class="section">
+            <h2>System Logs</h2>
+            <pre id="logOutput" style="background-color: #1E1E1E; color: #55FF55; padding: 10px; max-height: 300px; overflow-y: auto; font-family: monospace; border: 2px solid #1E1E1E;"></pre>
+            <button id="refreshLogsButton">Refresh Logs</button>
         </div>
 
         <div class="section">


### PR DESCRIPTION
This PR addresses several bugs and adds requested features:
- Fixes server.properties parsing to handle values containing equals signs.
- Implements a persistent server.pid file for better process tracking across management process restarts.
- Improves stopServer with a polling loop for reliable process termination.
- Adds support for a configurable uiPort via config and CLI.
- Implements a manual backup feature with a dedicated UI button.
- Adds a system log viewing feature in the web interface with efficient log reading.
- Updated .gitignore to exclude server.pid.

---
*PR created automatically by Jules for task [5695751809764842306](https://jules.google.com/task/5695751809764842306) started by @brettfxio*