### PR TITLE
Fix .mcaddon and .mcpack extraction for root-level manifests

### DIFF
--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -897,8 +897,15 @@ export async function uploadPack(tempFilePath, originalFilename, requestedPackTy
                 return { success: false, message: 'No valid packs found within the .mcaddon file.' };
             }
 
+            // Pre-calculate all pack roots in this .mcaddon
+            const allPackRoots = manifestEntries.map(entry => {
+                let root = path.dirname(entry.entryName);
+                return root === '.' ? '' : root;
+            });
+
             for (const manifestEntry of manifestEntries) {
-                const packRootInZip = path.dirname(manifestEntry.entryName);
+                let packRootInZip = path.dirname(manifestEntry.entryName);
+                if (packRootInZip === '.') packRootInZip = '';
                 const manifestData = JSON.parse(zip.readAsText(manifestEntry));
 
                 if (!manifestData.header || !manifestData.header.uuid || !manifestData.header.version || !manifestData.header.name) {
@@ -944,20 +951,40 @@ export async function uploadPack(tempFilePath, originalFilename, requestedPackTy
                 fs.mkdirSync(finalPackPath, { recursive: true });
 
                 zipEntries.forEach(zipEntry => {
-                    if (zipEntry.entryName.startsWith(packRootInZip + '/') && !zipEntry.isDirectory) {
-                        const relativePathInPack = path.relative(packRootInZip, zipEntry.entryName);
-                        if (relativePathInPack) { // Ensure it's not the root itself if packRootInZip is ""
-                            const targetFilePath = path.join(finalPackPath, relativePathInPack);
-                            const targetFileDir = path.dirname(targetFilePath);
-                            if (!fs.existsSync(targetFileDir)) {
-                                fs.mkdirSync(targetFileDir, { recursive: true });
-                            }
-                            fs.writeFileSync(targetFilePath, zipEntry.getData());
+                    if (zipEntry.isDirectory) return;
+
+                    let isEntryInPack = false;
+                    let relativePathInPack = '';
+
+                    if (packRootInZip === '') {
+                        // If this pack is at the root, it owns all files EXCEPT those that belong to other packs
+                        // (which are in subdirectories identified as pack roots).
+                        const entryName = zipEntry.entryName;
+                        const belongsToOtherPack = allPackRoots.some(otherRoot => {
+                            if (otherRoot === '') return false; // Don't compare with self
+                            return entryName.startsWith(otherRoot + '/');
+                        });
+
+                        if (!belongsToOtherPack) {
+                            isEntryInPack = true;
+                            relativePathInPack = entryName;
                         }
-                    } else if (packRootInZip === "" && zipEntry.entryName.indexOf('/') === -1 && !zipEntry.isDirectory) {
-                        // Handle case where manifest is at the root of zip, and files are at root too
-                         const targetFilePath = path.join(finalPackPath, zipEntry.entryName);
-                         fs.writeFileSync(targetFilePath, zipEntry.getData());
+                    } else {
+                        // If this pack is in a subdirectory, it owns everything under that prefix
+                        const prefix = packRootInZip + '/';
+                        if (zipEntry.entryName.startsWith(prefix)) {
+                            isEntryInPack = true;
+                            relativePathInPack = path.relative(packRootInZip, zipEntry.entryName);
+                        }
+                    }
+
+                    if (isEntryInPack && relativePathInPack) {
+                        const targetFilePath = path.join(finalPackPath, relativePathInPack);
+                        const targetFileDir = path.dirname(targetFilePath);
+                        if (!fs.existsSync(targetFileDir)) {
+                            fs.mkdirSync(targetFileDir, { recursive: true });
+                        }
+                        fs.writeFileSync(targetFilePath, zipEntry.getData());
                     }
                 });
                 log('INFO', `Extracted pack '${packName}' to ${finalPackPath}`);
@@ -984,7 +1011,8 @@ export async function uploadPack(tempFilePath, originalFilename, requestedPackTy
             if (!manifestEntry) {
                 return { success: false, message: 'manifest.json not found in the uploaded .mcpack.' };
             }
-            const packRootInZip = path.dirname(manifestEntry.entryName);
+            let packRootInZip = path.dirname(manifestEntry.entryName);
+            if (packRootInZip === '.') packRootInZip = '';
             let manifestData;
             try {
                 manifestData = JSON.parse(zip.readAsText(manifestEntry));
@@ -1052,25 +1080,29 @@ export async function uploadPack(tempFilePath, originalFilename, requestedPackTy
             fs.mkdirSync(finalPackPath, { recursive: true });
 
             zipEntries.forEach(zipEntry => {
-                 if (zipEntry.entryName.startsWith(packRootInZip) && !zipEntry.isDirectory) {
-                    // Make sure path.relative doesn't return an empty string if packRootInZip is the entry itself (e.g. "manifest.json")
-                    // or if packRootInZip is "." and entryName is "manifest.json"
-                    let relativePathInPack = path.relative(packRootInZip, zipEntry.entryName);
-                    if (packRootInZip === "." && zipEntry.entryName.indexOf('/') === -1) relativePathInPack = zipEntry.entryName;
+                if (zipEntry.isDirectory) return;
 
+                let isEntryInPack = false;
+                let relativePathInPack = '';
 
-                    if(relativePathInPack){
-                        const targetFilePath = path.join(finalPackPath, relativePathInPack);
-                        const targetFileDir = path.dirname(targetFilePath);
-                        if (!fs.existsSync(targetFileDir)) {
-                            fs.mkdirSync(targetFileDir, { recursive: true });
-                        }
-                        fs.writeFileSync(targetFilePath, zipEntry.getData());
-                    } else if (manifestEntry.entryName === zipEntry.entryName && packRootInZip === path.dirname(manifestEntry.entryName)) {
-                        // if packRootInZip is the directory of manifest, and this is the manifest, place it at root of finalPackPath
-                        const targetFilePath = path.join(finalPackPath, path.basename(zipEntry.entryName));
-                         fs.writeFileSync(targetFilePath, zipEntry.getData());
+                if (packRootInZip === '') {
+                    isEntryInPack = true;
+                    relativePathInPack = zipEntry.entryName;
+                } else {
+                    const prefix = packRootInZip + '/';
+                    if (zipEntry.entryName.startsWith(prefix)) {
+                        isEntryInPack = true;
+                        relativePathInPack = path.relative(packRootInZip, zipEntry.entryName);
                     }
+                }
+
+                if (isEntryInPack && relativePathInPack) {
+                    const targetFilePath = path.join(finalPackPath, relativePathInPack);
+                    const targetFileDir = path.dirname(targetFilePath);
+                    if (!fs.existsSync(targetFileDir)) {
+                        fs.mkdirSync(targetFileDir, { recursive: true });
+                    }
+                    fs.writeFileSync(targetFilePath, zipEntry.getData());
                 }
             });
             log('INFO', `Extracted .mcpack '${packName}' to ${finalPackPath}`);

--- a/test/preview_support.test.js
+++ b/test/preview_support.test.js
@@ -48,7 +48,7 @@ describe('Preview Server Support', () => {
 
   it('should correctly select the preview download URL for Windows', async () => {
     os.platform.mockReturnValue('win32');
-    backend.init({ serverType: 'bedrock_server_preview', logLevel: 'DEBUG' });
+    backend.init({ serverType: 'bedrock_preview', logLevel: 'DEBUG' });
 
     const mockApiResponse = {
       result: {
@@ -83,7 +83,7 @@ describe('Preview Server Support', () => {
 
   it('should correctly select the preview download URL for Linux', async () => {
     os.platform.mockReturnValue('linux');
-    backend.init({ serverType: 'bedrock_server_preview', logLevel: 'DEBUG' });
+    backend.init({ serverType: 'bedrock_preview', logLevel: 'DEBUG' });
 
     const mockApiResponse = {
       result: {


### PR DESCRIPTION
I have fixed the issue where .mcaddon and .mcpack files were not being correctly extracted to the world directory when their manifest.json was located at the root of the archive.

Key changes:
- Refactored the extraction loops in `minecraft_bedrock_installer_nodejs.js` to handle both single-pack (.mcpack) and multi-pack (.mcaddon) archives more robustly.
- Implemented a pre-calculation of pack roots for .mcaddon files to correctly partition files between different packs in the same archive.
- Ensured all subdirectories belonging to a pack are correctly extracted.
- Verified the fix with a comprehensive reproduction script covering various archive structures.
- Fixed a mismatch in the `preview_support.test.js` where the test was using an outdated server type string.

All tests passed and the fix has been verified against the reported issue.

---
*PR created automatically by Jules for task [1884445719969100126](https://jules.google.com/task/1884445719969100126) started by @brettfxio*