### PR TITLE
Add CLI support for --serverType and update preview detection

### DIFF
--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -183,7 +183,7 @@ export async function getLatestVersion() {
                 try {
                     const jsonResponse = JSON.parse(data);
                     let targetDownloadType;
-                    if (serverType === 'bedrock_preview') {
+                    if (serverType === 'bedrock_preview' || serverType === 'bedrock_server_preview') {
                         targetDownloadType = platform === 'win32' ? 'serverBedrockPreviewWindows' : 'serverBedrockPreviewLinux';
                     } else {
                         targetDownloadType = platform === 'win32' ? 'serverBedrockWindows' : 'serverBedrockLinux';
@@ -809,6 +809,7 @@ export async function readGlobalConfig() {
             case '--autoStart': effectiveConfig.autoStart = (valueConsumed ? (value === 'true') : true); break;
             case '--autoUpdateEnabled': effectiveConfig.autoUpdateEnabled = (valueConsumed ? (value === 'true') : true); break;
             case '--logLevel': if(valueConsumed) effectiveConfig.logLevel = value.toUpperCase(); break;
+            case '--serverType': if(valueConsumed) effectiveConfig.serverType = value; break;
             default: valueConsumed = false;
         }
         if (valueConsumed) { log('DEBUG', `CLI Override: ${arg} = ${args[i+1]}`); i++; }

--- a/test/preview_support.test.js
+++ b/test/preview_support.test.js
@@ -115,4 +115,39 @@ describe('Preview Server Support', () => {
       downloadUrl: 'https://example.com/bedrock-server-1.21.0.2.zip',
     });
   });
+
+  it('should correctly select the preview download URL when serverType is bedrock_server_preview', async () => {
+    os.platform.mockReturnValue('linux');
+    backend.init({ serverType: 'bedrock_server_preview', logLevel: 'DEBUG' });
+
+    const mockApiResponse = {
+      result: {
+        links: [
+          { downloadType: 'serverBedrockLinux', downloadUrl: 'https://example.com/bedrock-server-1.20.0.1.zip' },
+          { downloadType: 'serverBedrockPreviewLinux', downloadUrl: 'https://example.com/bedrock-server-1.21.0.3.zip' },
+        ],
+      },
+    };
+
+    const mockResponse = new EventEmitter();
+    mockResponse.statusCode = 200;
+
+    https.get.mockImplementation((url, options, callback) => {
+        if (typeof options === 'function') {
+            callback = options;
+        }
+
+        callback(mockResponse);
+        mockResponse.emit('data', JSON.stringify(mockApiResponse));
+        mockResponse.emit('end');
+        return new EventEmitter();
+    });
+
+    const result = await backend.getLatestVersion();
+
+    expect(result).toEqual({
+      latestVersion: '1.21.0.3',
+      downloadUrl: 'https://example.com/bedrock-server-1.21.0.3.zip',
+    });
+  });
 });


### PR DESCRIPTION
This change enables setting the server type via the command line using the --serverType argument. It also updates the version detection logic to treat 'bedrock_server_preview' as synonymous with 'bedrock_preview' when fetching the latest version from the Minecraft download API. A new test case has been added to verify this behavior.

---
*PR created automatically by Jules for task [296083113939978945](https://jules.google.com/task/296083113939978945) started by @brettfxio*