### PR TITLE
Add HTTP API documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,138 @@
+# Bedrock Server Manager HTTP API Documentation
+
+This document describes the HTTP API provided by the Bedrock Server Manager. All API endpoints are prefixed with `/api`.
+
+## Server Control
+
+### GET /api/status
+Returns the current status of the Minecraft server process.
+
+**Response:**
+- `200 OK`: `{ "status": "running" | "stopped" }`
+- `500 Internal Server Error`: `{ "error": "Failed to get server status" }`
+
+---
+
+### POST /api/start
+Starts the Minecraft server if it's not already running.
+
+**Response:**
+- `200 OK`: `{ "success": true, "message": "Server start initiated." }`
+- `500 Internal Server Error`: `{ "error": "Failed to start server" }`
+
+---
+
+### POST /api/stop
+Stops the Minecraft server if it's running.
+
+**Response:**
+- `200 OK`: `{ "success": true, "message": "Server stop initiated." }`
+- `500 Internal Server Error`: `{ "error": "Failed to stop server" }`
+
+---
+
+### POST /api/restart
+Restarts the Minecraft server.
+
+**Response:**
+- `200 OK`: `{ "success": true, "message": "Server restart initiated." }`
+- `500 Internal Server Error`: `{ "error": "Failed to restart server" }`
+
+---
+
+### POST /api/update
+Checks for Minecraft server updates and installs them if available. This involves stopping the server, backing up data, downloading the new version, restoring data, and restarting the server.
+
+**Response:**
+- `200 OK`: `{ "success": boolean, "message": string }`
+- `500 Internal Server Error`: `{ "error": "Failed to check/install update" }`
+
+---
+
+## Server Properties
+
+### GET /api/properties
+Retrieves the current `server.properties` configuration.
+
+**Response:**
+- `200 OK`: `{ "success": true, "properties": { "key": "value", ... } }`
+- `500 Internal Server Error`: `{ "error": "Failed to read server properties" }`
+
+---
+
+### POST /api/properties
+Updates the `server.properties` file. Note that a server restart is required for changes to take effect.
+
+**Request Body:**
+JSON object containing the property keys and values to update.
+
+**Response:**
+- `200 OK`: `{ "success": true, "message": "Server properties updated. Restart server for changes to take effect." }`
+- `400 Bad Request`: `{ "error": string }` (if validation fails)
+- `500 Internal Server Error`: `{ "error": "Failed to write server properties" }`
+
+---
+
+## World Management
+
+### GET /api/worlds
+Lists all world folders found in the server's `worlds` directory.
+
+**Response:**
+- `200 OK`: `{ "success": true, "worlds": ["world1", "world2", ...] }`
+- `500 Internal Server Error`: `{ "error": "Failed to list worlds" }`
+
+---
+
+### POST /api/activate-world
+Sets a specific world as active by updating the `level-name` in `server.properties`. This endpoint also triggers a server restart.
+
+**Request Body:**
+`{ "worldName": "string" }`
+
+**Response:**
+- `200 OK`: `{ "message": "World 'worldName' activated." }`
+- `400 Bad Request`: `{ "error": string }` (if world name is missing or invalid)
+- `500 Internal Server Error`: `{ "error": "Failed to activate world" }`
+
+---
+
+## Application Configuration
+
+### GET /api/config
+Retrieves the current application configuration (e.g., auto-update settings).
+
+**Response:**
+- `200 OK`: `{ "success": true, "config": { ... } }`
+- `500 Internal Server Error`: `{ "error": "Failed to get application config" }`
+
+---
+
+### POST /api/config
+Updates the application configuration settings.
+
+**Request Body:**
+`{ "autoUpdateEnabled": boolean, "autoUpdateIntervalMinutes": number, "logLevel": "string" }` (All fields are optional)
+
+**Response:**
+- `200 OK`: `{ "success": true, "message": "Global config settings updated successfully." }`
+- `500 Internal Server Error`: `{ "error": "Failed to set global config" }`
+
+---
+
+## Pack Management
+
+### POST /api/upload-pack
+Uploads and applies a behavior or resource pack (`.mcpack` or `.mcaddon`) to a specific world.
+
+**Request Type:** `multipart/form-data`
+
+**Parameters:**
+- `packFile`: The `.mcpack` or `.mcaddon` file.
+- `worldName`: (string, required) The target world for the pack.
+- `packType`: (string, optional) The type of pack if uploading a single `.mcpack`. Options: `behavior`, `resource`, `dev_behavior`, `dev_resource`. Auto-detected if omitted.
+
+**Response:**
+- `200 OK`: `{ "success": true, "message": string }`
+- `400 Bad Request`: `{ "success": false, "message": string }` (if file missing, invalid type, or world not found)
+- `500 Internal Server Error`: `{ "success": false, "message": "Failed to upload pack due to server error." }`

--- a/README.md
+++ b/README.md
@@ -16,22 +16,23 @@ This application provides a web-based interface to manage a single Minecraft Bed
 ## What's Inside?
 
 1.  [Prerequisites](#1-prerequisites)
-2.  [Node.js Installation](#2-nodejs-installation)
+2.  [HTTP API Documentation](API.md)
+3.  [Node.js Installation](#2-nodejs-installation)
     *   [Windows](#nodejs-for-windows)
     *   [Linux](#nodejs-for-linux)
-3.  [Application Setup](#3-application-setup)
+4.  [Application Setup](#3-application-setup)
     *   [Configuration (`config.json`)](#configuration-configjson)
     *   [Command-Line Overrides](#command-line-overrides)
-4.  [Starting the Application](#4-starting-the-application)
-5.  [Testing](#5-testing)
-6.  [Basic Usage](#6-basic-usage)
+5.  [Starting the Application](#4-starting-the-application)
+6.  [Testing](#5-testing)
+7.  [Basic Usage](#6-basic-usage)
     *   [Server Information](#server-information)
     *   [Server Controls](#server-controls)
     *   [Auto-Update Settings](#auto-update-settings)
     *   [World Management](#world-management)
     *   [Server Properties](#server-properties)
     *   [Pack Management](#pack-management)
-7.  [Running Multiple Server Managers](#7-running-multiple-server-managers)
+8.  [Running Multiple Server Managers](#7-running-multiple-server-managers)
 
 ---
 
@@ -42,6 +43,12 @@ This application provides a web-based interface to manage a single Minecraft Bed
 *   **System Utilities:**
     *   **Linux:** `unzip` is required for extracting server files. Install via `sudo apt-get install unzip` (Debian/Ubuntu) or `sudo yum install unzip` (CentOS/RHEL).
     *   **Windows:** PowerShell (typically version 5.1+) is required for server extraction. This is usually available by default on modern Windows systems.
+
+---
+
+## HTTP API Documentation
+
+Detailed information about the HTTP API endpoints can be found in [API.md](API.md).
 
 ---
 


### PR DESCRIPTION
This pull request adds comprehensive HTTP API documentation for the Bedrock Server Manager. 

Key changes:
- Created \`API.md\` which documents all 12 endpoints under the \`/api\` prefix, including request methods, parameters, and response formats.
- Updated \`README.md\` to include a link to the new \`API.md\` file in the "What's Inside?" section and added a dedicated "HTTP API Documentation" section.
- Verified that all existing tests pass after these additions.

---
*PR created automatically by Jules for task [12458002790475641355](https://jules.google.com/task/12458002790475641355) started by @brettfxio*