### PR TITLE
Improve robustness, PID management, and logging consistency

### DIFF
--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -250,9 +250,9 @@ export function extractFiles(zipPath, extractPath) {
             try {
                 // Set permissions to 755 (owner can read/write/execute, others can read/execute)
                 fs.chmodSync(executableFilePath, 0o755);
-                console.log(`Permissions set to 755 for ${executableFilePath}`);
+                log('INFO', `Permissions set to 755 for ${executableFilePath}`);
             } catch (err) {
-                console.error(`Failed to set permissions for ${executableFilePath}:`, err);
+                log('ERROR', `Failed to set permissions for ${executableFilePath}: ${err.message}`);
             }
 
             resolve();
@@ -391,21 +391,29 @@ export async function copyExistingData(backupDir, newInstallDir) {
     log('INFO', 'Finished copying existing data.');
 }
 
-export async function stopServer() {
-    if (!serverPID && SERVER_DIRECTORY) {
-        const pidFile = pathJoin(SERVER_DIRECTORY, 'server.pid');
-        if (fs.existsSync(pidFile)) {
-            try {
-                const pid = parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10);
-                if (!isNaN(pid)) {
-                    serverPID = pid;
-                    log('INFO', `Recovered server PID from file for stopping: ${serverPID}`);
-                }
-            } catch (error) {
-                log('ERROR', `Failed to read PID file for stopping: ${error.message}`);
+function recoverPID() {
+    if (serverPID) return serverPID;
+    if (!SERVER_DIRECTORY) return null;
+
+    const pidFile = pathJoin(SERVER_DIRECTORY, 'server.pid');
+    if (fs.existsSync(pidFile)) {
+        try {
+            const pidString = fs.readFileSync(pidFile, 'utf8').trim();
+            const pid = parseInt(pidString, 10);
+            if (!isNaN(pid)) {
+                serverPID = pid;
+                log('INFO', `Recovered server PID from file: ${serverPID}`);
+                return serverPID;
             }
+        } catch (error) {
+            log('ERROR', `Failed to read PID file: ${error.message}`);
         }
     }
+    return null;
+}
+
+export async function stopServer() {
+    recoverPID();
 
     if (!serverPID) {
         log('INFO', `Server process PID not found. Server may already be stopped.`);
@@ -474,7 +482,7 @@ export async function startServer() {
         const serverProcess = spawn(serverExePath, [], {
             cwd: SERVER_DIRECTORY,
             stdio: 'inherit',
-            detached: false
+            detached: true
         });
         if (serverProcess.pid) {
             serverPID = serverProcess.pid;
@@ -554,7 +562,17 @@ export async function checkAndInstall() {
             log('INFO', `Removed existing server directory ${SERVER_DIRECTORY}`);
         }
         log('INFO', `Moving new server files from ${tempInstallPath} to ${SERVER_DIRECTORY}`);
-        fs.renameSync(tempInstallPath, SERVER_DIRECTORY);
+        try {
+            fs.renameSync(tempInstallPath, SERVER_DIRECTORY);
+        } catch (renameError) {
+            if (renameError.code === 'EXDEV') {
+                log('INFO', `Cross-device link error (EXDEV) during rename. Falling back to copy-and-delete.`);
+                fs.cpSync(tempInstallPath, SERVER_DIRECTORY, { recursive: true });
+                fs.rmSync(tempInstallPath, { recursive: true, force: true });
+            } else {
+                throw renameError;
+            }
+        }
         log('INFO', 'Successfully moved new server files to SERVER_DIRECTORY.');
         if (backupDir) {
             await copyExistingData(backupDir, SERVER_DIRECTORY);
@@ -597,11 +615,15 @@ export async function readServerProperties() {
     }
     const data = await fs.promises.readFile(configPath, 'utf8');
     const properties = {};
-    data.split('\n').forEach(line => {
+    data.split(/\r?\n/).forEach(line => {
         const trimmedLine = line.trim();
         if (trimmedLine && !trimmedLine.startsWith('#')) {
-            const [key, value] = trimmedLine.split('=').map(s => s.trim());
-            if (key) { properties[key] = value || ''; }
+            const separatorIndex = trimmedLine.indexOf('=');
+            if (separatorIndex !== -1) {
+                const key = trimmedLine.substring(0, separatorIndex).trim();
+                const value = trimmedLine.substring(separatorIndex + 1).trim();
+                if (key) { properties[key] = value; }
+            }
         }
     });
     log('INFO', `Read server.properties from ${configPath}`);
@@ -683,21 +705,7 @@ export async function restartServer() {
 }
 
 export async function isProcessRunning() {
-    if (!serverPID && SERVER_DIRECTORY) {
-        const pidFile = pathJoin(SERVER_DIRECTORY, 'server.pid');
-        if (fs.existsSync(pidFile)) {
-            try {
-                const pidString = fs.readFileSync(pidFile, 'utf8').trim();
-                const pid = parseInt(pidString, 10);
-                if (!isNaN(pid)) {
-                    serverPID = pid;
-                    log('INFO', `Recovered server PID from file: ${serverPID}`);
-                }
-            } catch (error) {
-                log('ERROR', `Failed to read PID file: ${error.message}`);
-            }
-        }
-    }
+    recoverPID();
 
     if (!serverPID) {
         log('DEBUG', `No PID found for server. Assuming not running.`);

--- a/test/minecraft_bedrock_installer_nodejs.test.js
+++ b/test/minecraft_bedrock_installer_nodejs.test.js
@@ -76,6 +76,21 @@ gamemode=survival
 
         expect(properties).toEqual({});
     });
+
+    it('should handle property values with equals signs and different line endings', async () => {
+        const mockProperties = "server-name=My=Server\r\nlevel-seed=12345\nother-prop=value=with=equals";
+        fs.existsSync.mockReturnValue(true);
+        fs.promises.readFile.mockResolvedValue(mockProperties);
+        backend.init({ serverDirectory: '/test/server' });
+
+        const properties = await backend.readServerProperties();
+
+        expect(properties).toEqual({
+            'server-name': 'My=Server',
+            'level-seed': '12345',
+            'other-prop': 'value=with=equals'
+        });
+    });
   });
 
   describe('readGlobalConfig', () => {


### PR DESCRIPTION
This PR addresses several robustness and maintainability issues in the Minecraft Bedrock installer.

Key improvements:
1. **Robust Property Parsing**: The `readServerProperties` function now correctly parses properties where the value itself contains an equals sign (e.g., `server-name=My=Server`). It also correctly handles Windows-style CRLF line endings by using a more flexible regex split.
2. **Cross-Partition Support**: The update/installation process now includes a fallback for file movement. If `fs.renameSync` fails with an `EXDEV` error (which happens when moving files between different filesystems or partitions), the manager will automatically fall back to a copy-and-delete strategy using `fs.cpSync` and `fs.rmSync`.
3. **Refactored PID Management**: PID recovery logic has been centralized into a single `recoverPID` helper function, ensuring consistent behavior across `stopServer` and `isProcessRunning`.
4. **Improved Process Spawning**: The Minecraft server process is now spawned with `detached: true`, which is standard practice for processes intended to outlive the immediate lifecycle of their launcher script.
5. **Logging Consistency**: Direct `console` calls in the backend module have been replaced with the internal `log()` utility to ensure consistent formatting and log level adherence.
6. **New Test Case**: A unit test has been added to `test/minecraft_bedrock_installer_nodejs.test.js` to verify the property parsing fixes and prevent regressions.

---
*PR created automatically by Jules for task [15230528706922296276](https://jules.google.com/task/15230528706922296276) started by @brettfxio*