### PR TITLE
Bugs fixes and enhancements for Bedrock Server Manager

### DIFF
--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -25,7 +25,7 @@ let serverPID = null;
 
 const LAST_VERSION_FILE = 'last_version.txt';
 const WEBHOOK_URL = process.env.MC_UPDATE_WEBHOOK;
-const CONFIG_FILES = ['server.properties', 'permissions.json', 'whitelist.json'];
+const CONFIG_FILES = ['server.properties', 'permissions.json', 'whitelist.json', 'allowlist.json'];
 const WORLD_DIRECTORIES = ['worlds'];
 const GLOBAL_CONFIG_FILE = 'config.json';
 
@@ -45,12 +45,12 @@ function setLogLevel(levelName) {
         // or if we are increasing verbosity to INFO from something more restrictive.
         if (LOG_LEVELS.INFO >= currentLogLevel && (LOG_LEVELS.INFO >= oldLogLevel || currentLogLevel <= oldLogLevel) ) {
             const initialLogMessage = `${new Date().toISOString()} [INFO] Log level set to ${levelNameToUse}\n`;
-            console.log(initialLogMessage);
+            process.stdout.write(initialLogMessage);
             logStream.write(initialLogMessage);
         }
     } else {
         const warningMessage = `${new Date().toISOString()} [WARNING] Invalid log level: ${levelName}. Defaulting to INFO.\n`;
-        console.warn(warningMessage);
+        process.stderr.write(warningMessage);
         logStream.write(warningMessage);
         currentLogLevel = LOG_LEVELS.INFO;
     }
@@ -59,14 +59,14 @@ function setLogLevel(levelName) {
 export function log(level, message) {
     const messageLevel = LOG_LEVELS[level.toUpperCase()];
     if (messageLevel === undefined) {
-        console.warn(`Invalid log level used in log() call: ${level}`);
+        process.stderr.write(`Invalid log level used in log() call: ${level}\n`);
         return;
     }
     if (messageLevel >= currentLogLevel) {
-        const timestamp = new Date().toISOString();
-        const logMessage = `${timestamp} [${level.toUpperCase()}] ${message}\n`;
-        console.log(logMessage);
-        logStream.write(logMessage);
+        const timestamp = new Date().toISOString();
+        const logMessage = `${timestamp} [${level.toUpperCase()}] ${message}\n`;
+        process.stdout.write(logMessage);
+        logStream.write(logMessage);
     }
 }
 
@@ -165,8 +165,6 @@ export async function getLatestVersion() {
             log('ERROR', error.message);
             throw error;
         }
-
-        return { latestVersion: version, downloadUrl: downloadUrl };
     }
 
     // Default to bedrock
@@ -219,25 +217,25 @@ export async function getLatestVersion() {
 }
 
 export function downloadFile(downloadUrl, downloadPath) {
-    return new Promise((resolve, reject) => {
-        const url = new URL(downloadUrl);
-        const protocol = url.protocol === 'https:' ? https : http;
-        const file = fs.createWriteStream(downloadPath);
-        protocol.get(url, (response) => {
-            if (response.statusCode < 200 || response.statusCode >= 300) {
-                reject(new Error(`Failed to download file: ${response.statusCode} ${response.statusMessage}`));
-                return;
-            }
-            response.pipe(file);
-            file.on('finish', () => { file.close(resolve); });
-            file.on('error', (err) => { fs.unlink(downloadPath, () => reject(new Error(`Error writing to file: ${err.message}`))); });
-            response.on('error', (err) => { fs.unlink(downloadPath, () => reject(new Error(`Error during download: ${err.message}`))); });
-        });
-    });
+    return new Promise((resolve, reject) => {
+        const url = new URL(downloadUrl);
+        const protocol = url.protocol === 'https:' ? https : http;
+        const file = fs.createWriteStream(downloadPath);
+        protocol.get(url, (response) => {
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+                reject(new Error(`Failed to download file: ${response.statusCode} ${response.statusMessage}`));
+                return;
+            }
+            response.pipe(file);
+            file.on('finish', () => { file.close(resolve); });
+            file.on('error', (err) => { fs.unlink(downloadPath, () => reject(new Error(`Error writing to file: ${err.message}`))); });
+            response.on('error', (err) => { fs.unlink(downloadPath, () => reject(new Error(`Error during download: ${err.message}`))); });
+        });
+    });
 }
 
 export function extractFiles(zipPath, extractPath) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         try {
             log('INFO', `Using adm-zip for extraction for ${zipPath} to ${extractPath}.`);
             const zip = new AdmZip(zipPath);
@@ -255,12 +253,12 @@ export function extractFiles(zipPath, extractPath) {
                 log('ERROR', `Failed to set permissions for ${executableFilePath}: ${err.message}`);
             }
 
-            resolve();
+            resolve();
         } catch (error) {
             log('ERROR', `Extraction failed for ${zipPath}: ${error.message}`);
             reject(new Error(`Extraction failed: ${error.message}`));
-        }
-    });
+        }
+    });
 }
 
 export async function changeOwnership(dirPath, user, group) {
@@ -391,20 +389,33 @@ export async function copyExistingData(backupDir, newInstallDir) {
     log('INFO', 'Finished copying existing data.');
 }
 
-export async function stopServer() {
-    if (!serverPID && SERVER_DIRECTORY) {
+/**
+ * Attempts to recover the server PID from the server.pid file.
+ * @returns {number|null} The recovered PID, or null if not found or invalid.
+ */
+function recoverPID() {
+    if (SERVER_DIRECTORY) {
         const pidFile = pathJoin(SERVER_DIRECTORY, 'server.pid');
         if (fs.existsSync(pidFile)) {
             try {
-                const pid = parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10);
+                const pidString = fs.readFileSync(pidFile, 'utf8').trim();
+                const pid = parseInt(pidString, 10);
                 if (!isNaN(pid)) {
                     serverPID = pid;
-                    log('INFO', `Recovered server PID from file for stopping: ${serverPID}`);
+                    log('INFO', `Recovered server PID from file: ${serverPID}`);
+                    return serverPID;
                 }
             } catch (error) {
-                log('ERROR', `Failed to read PID file for stopping: ${error.message}`);
+                log('ERROR', `Failed to read PID file: ${error.message}`);
             }
         }
+    }
+    return null;
+}
+
+export async function stopServer() {
+    if (!serverPID) {
+        recoverPID();
     }
 
     if (!serverPID) {
@@ -471,11 +482,11 @@ export async function startServer() {
             return;
         }
         log('INFO', `Starting Minecraft server from ${serverExePath}`);
-        const serverProcess = spawn(serverExePath, [], {
-            cwd: SERVER_DIRECTORY,
-            stdio: ['ignore', 'pipe', 'pipe'],
-            detached: false
-        });
+        const serverProcess = spawn(serverExePath, [], {
+            cwd: SERVER_DIRECTORY,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            detached: true
+        });
         if (serverProcess.pid) {
             serverPID = serverProcess.pid;
             log('INFO', `Server process started with PID: ${serverPID}.`);
@@ -635,22 +646,26 @@ export async function clearServerLogs() {
 }
 
 export async function readServerProperties() {
-    const configPath = pathJoin(SERVER_DIRECTORY, 'server.properties');
-    if (!SERVER_DIRECTORY || !fs.existsSync(configPath)) { // Check SERVER_DIRECTORY is defined
-        log('WARNING', `server.properties not found at ${configPath} (or server directory not set). Returning empty config.`);
-        return {};
-    }
-    const data = await fs.promises.readFile(configPath, 'utf8');
-    const properties = {};
-    data.split('\n').forEach(line => {
-        const trimmedLine = line.trim();
-        if (trimmedLine && !trimmedLine.startsWith('#')) {
-            const [key, value] = trimmedLine.split('=').map(s => s.trim());
-            if (key) { properties[key] = value || ''; }
-        }
-    });
-    log('INFO', `Read server.properties from ${configPath}`);
-    return properties;
+    const configPath = pathJoin(SERVER_DIRECTORY, 'server.properties');
+    if (!SERVER_DIRECTORY || !fs.existsSync(configPath)) { // Check SERVER_DIRECTORY is defined
+        log('WARNING', `server.properties not found at ${configPath} (or server directory not set). Returning empty config.`);
+        return {};
+    }
+    const data = await fs.promises.readFile(configPath, 'utf8');
+    const properties = {};
+    data.split(/\r?\n/).forEach(line => {
+        const trimmedLine = line.trim();
+        if (trimmedLine && !trimmedLine.startsWith('#')) {
+            const separatorIndex = trimmedLine.indexOf('=');
+            if (separatorIndex !== -1) {
+                const key = trimmedLine.substring(0, separatorIndex).trim();
+                const value = trimmedLine.substring(separatorIndex + 1).trim();
+                if (key) { properties[key] = value; }
+            }
+        }
+    });
+    log('INFO', `Read server.properties from ${configPath}`);
+    return properties;
 }
 
 export async function writeServerProperties(propertiesToWrite) {
@@ -762,20 +777,8 @@ export async function restartServer() {
 }
 
 export async function isProcessRunning() {
-    if (!serverPID && SERVER_DIRECTORY) {
-        const pidFile = pathJoin(SERVER_DIRECTORY, 'server.pid');
-        if (fs.existsSync(pidFile)) {
-            try {
-                const pidString = fs.readFileSync(pidFile, 'utf8').trim();
-                const pid = parseInt(pidString, 10);
-                if (!isNaN(pid)) {
-                    serverPID = pid;
-                    log('INFO', `Recovered server PID from file: ${serverPID}`);
-                }
-            } catch (error) {
-                log('ERROR', `Failed to read PID file: ${error.message}`);
-            }
-        }
+    if (!serverPID) {
+        recoverPID();
     }
 
     if (!serverPID) {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -79,7 +79,7 @@
             <div class="world-list">
                 <% if (worlds && worlds.length > 0) { %>
                     <% worlds.forEach(world => { %>
-                        <li class="world-item <%= properties['level-name'] === world ? 'active' : '' %>" data-world-name="<%= world %>">
+                        <div class="world-item <%= properties['level-name'] === world ? 'active' : '' %>" data-world-name="<%= world %>">
                             <span><%= world %></span>
                             <button class="activate-world-button" data-world-name="<%= world %>">
                                 Activate
@@ -89,7 +89,7 @@
                                     Delete
                                 </button>
                             <% } %>
-                        </li>
+                        </div>
                     <% }); %>
                 <% } else { %>
                     <p>No worlds found. Start the server to generate a default world.</p>


### PR DESCRIPTION
This PR addresses several bugs and implement enhancements in the Bedrock Server Manager:

1.  **PID Recovery:** Centralized the logic to recover the server PID from `server.pid` into a new `recoverPID()` function, which is now used by both `isProcessRunning()` and `stopServer()`.
2.  **Server Properties Parsing:** Updated `readServerProperties()` to use `indexOf('=')` instead of `split('=')` to correctly handle property values that contain equals signs. It also now supports both LF and CRLF line endings.
3.  **Education Edition Support:** Fixed a bug in `getLatestVersion()` where an unreachable and incorrect return statement was present.
4.  **Configuration Preservation:** Added `allowlist.json` to the list of configuration files preserved during server updates.
5.  **Process Management:** Set the `detached` flag to `true` when spawning the Minecraft server process to allow more robust process management.
6.  **UI Consistency:** Updated `views/index.ejs` to use `<div>` elements for world items instead of `<li>`, matching the dynamic DOM generation in `script.js` and fixing invalid HTML.
7.  **Code Quality:** Replaced `console.log` and `console.warn` with `process.stdout.write` and `process.stderr.write` within the backend module for better stream control. Also performed a general cleanup of non-standard whitespace and indentation.

All tests passed successfully.

---
*PR created automatically by Jules for task [3534895070087235131](https://jules.google.com/task/3534895070087235131) started by @brettfxio*