### PR TITLE
Fix Property Parsing, Terminology, and HTML Structure

### DIFF
--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -25,7 +25,7 @@ let serverPID = null;
 
 const LAST_VERSION_FILE = 'last_version.txt';
 const WEBHOOK_URL = process.env.MC_UPDATE_WEBHOOK;
-const CONFIG_FILES = ['server.properties', 'permissions.json', 'whitelist.json'];
+const CONFIG_FILES = ['server.properties', 'permissions.json', 'whitelist.json', 'allowlist.json'];
 const WORLD_DIRECTORIES = ['worlds'];
 const GLOBAL_CONFIG_FILE = 'config.json';
 
@@ -635,22 +635,26 @@ export async function clearServerLogs() {
 }
 
 export async function readServerProperties() {
-    const configPath = pathJoin(SERVER_DIRECTORY, 'server.properties');
-    if (!SERVER_DIRECTORY || !fs.existsSync(configPath)) { // Check SERVER_DIRECTORY is defined
-        log('WARNING', `server.properties not found at ${configPath} (or server directory not set). Returning empty config.`);
-        return {};
-    }
-    const data = await fs.promises.readFile(configPath, 'utf8');
-    const properties = {};
-    data.split('\n').forEach(line => {
-        const trimmedLine = line.trim();
-        if (trimmedLine && !trimmedLine.startsWith('#')) {
-            const [key, value] = trimmedLine.split('=').map(s => s.trim());
-            if (key) { properties[key] = value || ''; }
-        }
-    });
-    log('INFO', `Read server.properties from ${configPath}`);
-    return properties;
+    const configPath = pathJoin(SERVER_DIRECTORY, 'server.properties');
+    if (!SERVER_DIRECTORY || !fs.existsSync(configPath)) { // Check SERVER_DIRECTORY is defined
+        log('WARNING', `server.properties not found at ${configPath} (or server directory not set). Returning empty config.`);
+        return {};
+    }
+    const data = await fs.promises.readFile(configPath, 'utf8');
+    const properties = {};
+    data.split(/\r?\n/).forEach(line => {
+        const trimmedLine = line.trim();
+        if (trimmedLine && !trimmedLine.startsWith('#')) {
+            const index = trimmedLine.indexOf('=');
+            if (index !== -1) {
+                const key = trimmedLine.substring(0, index).trim();
+                const value = trimmedLine.substring(index + 1).trim();
+                if (key) { properties[key] = value; }
+            }
+        }
+    });
+    log('INFO', `Read server.properties from ${configPath}`);
+    return properties;
 }
 
 export async function writeServerProperties(propertiesToWrite) {

--- a/test/bug_repro.test.js
+++ b/test/bug_repro.test.js
@@ -1,0 +1,45 @@
+import * as backend from '../minecraft_bedrock_installer_nodejs.js';
+import * as fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Bug Reproductions', () => {
+    const testServerDir = path.join(__dirname, 'test_server_props');
+
+    beforeAll(() => {
+        if (!fs.existsSync(testServerDir)) {
+            fs.mkdirSync(testServerDir, { recursive: true });
+        }
+        backend.init({
+            serverDirectory: testServerDir,
+            tempDirectory: path.join(__dirname, 'temp'),
+            backupDirectory: path.join(__dirname, 'backup'),
+            logLevel: 'ERROR'
+        });
+    });
+
+    afterAll(() => {
+        fs.rmSync(testServerDir, { recursive: true, force: true });
+    });
+
+    test('readServerProperties should handle values with equals signs', async () => {
+        const propsContent = 'server-name=My=Server\nlevel-name=world\n';
+        fs.writeFileSync(path.join(testServerDir, 'server.properties'), propsContent);
+
+        const props = await backend.readServerProperties();
+        expect(props['server-name']).toBe('My=Server');
+        expect(props['level-name']).toBe('world');
+    });
+
+    test('readServerProperties should handle CRLF', async () => {
+        const propsContent = 'server-name=My Server\r\nlevel-name=world\r\n';
+        fs.writeFileSync(path.join(testServerDir, 'server.properties'), propsContent);
+
+        const props = await backend.readServerProperties();
+        expect(props['server-name']).toBe('My Server');
+        expect(props['level-name']).toBe('world');
+    });
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -79,7 +79,7 @@
             <div class="world-list">
                 <% if (worlds && worlds.length > 0) { %>
                     <% worlds.forEach(world => { %>
-                        <li class="world-item <%= properties['level-name'] === world ? 'active' : '' %>" data-world-name="<%= world %>">
+                        <div class="world-item <%= properties['level-name'] === world ? 'active' : '' %>" data-world-name="<%= world %>">
                             <span><%= world %></span>
                             <button class="activate-world-button" data-world-name="<%= world %>">
                                 Activate
@@ -89,7 +89,7 @@
                                     Delete
                                 </button>
                             <% } %>
-                        </li>
+                        </div>
                     <% }); %>
                 <% } else { %>
                     <p>No worlds found. Start the server to generate a default world.</p>


### PR DESCRIPTION
I have identified and fixed several bugs and made enhancements to the Bedrock Server Manager. These include fixing a bug where Minecraft server properties with equals signs were being incorrectly parsed, adding support for CRLF line endings in config files, ensuring `allowlist.json` is preserved during updates, and correcting an HTML structural error in the world management interface. I've also added a new test file to verify these changes and ensure no future regressions.

---
*PR created automatically by Jules for task [13028070373403009826](https://jules.google.com/task/13028070373403009826) started by @brettfxio*