### PR TITLE
Fix property parsing and enhance UI for Bedrock Server Manager

### DIFF
--- a/app.js
+++ b/app.js
@@ -285,6 +285,7 @@ app.post('/api/config', async (req, res) => {
             currentFullConfig.logLevel = level;
         }
         await backend.writeGlobalConfig(currentFullConfig);
+        backend.init(currentFullConfig);
         await backend.startAutoUpdateScheduler();
         res.json({ success: true, message: 'Global config settings updated successfully.' });
     } catch (error) {

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -25,7 +25,7 @@ let serverPID = null;
 
 const LAST_VERSION_FILE = 'last_version.txt';
 const WEBHOOK_URL = process.env.MC_UPDATE_WEBHOOK;
-const CONFIG_FILES = ['server.properties', 'permissions.json', 'whitelist.json'];
+const CONFIG_FILES = ['server.properties', 'permissions.json', 'whitelist.json', 'allowlist.json'];
 const WORLD_DIRECTORIES = ['worlds'];
 const GLOBAL_CONFIG_FILE = 'config.json';
 
@@ -640,15 +640,19 @@ export async function readServerProperties() {
         log('WARNING', `server.properties not found at ${configPath} (or server directory not set). Returning empty config.`);
         return {};
     }
-    const data = await fs.promises.readFile(configPath, 'utf8');
-    const properties = {};
-    data.split('\n').forEach(line => {
-        const trimmedLine = line.trim();
-        if (trimmedLine && !trimmedLine.startsWith('#')) {
-            const [key, value] = trimmedLine.split('=').map(s => s.trim());
-            if (key) { properties[key] = value || ''; }
-        }
-    });
+    const data = await fs.promises.readFile(configPath, 'utf8');
+    const properties = {};
+    data.split(/\r?\n/).forEach(line => {
+        const trimmedLine = line.trim();
+        if (trimmedLine && !trimmedLine.startsWith('#')) {
+            const separatorIndex = trimmedLine.indexOf('=');
+            if (separatorIndex !== -1) {
+                const key = trimmedLine.substring(0, separatorIndex).trim();
+                const value = trimmedLine.substring(separatorIndex + 1).trim();
+                if (key) { properties[key] = value; }
+            }
+        }
+    });
     log('INFO', `Read server.properties from ${configPath}`);
     return properties;
 }

--- a/test/minecraft_bedrock_installer_nodejs.test.js
+++ b/test/minecraft_bedrock_installer_nodejs.test.js
@@ -76,6 +76,23 @@ gamemode=survival
 
         expect(properties).toEqual({});
     });
+
+    it('should handle property values containing equals signs', async () => {
+      const mockProperties = `
+server-name=My=Server=Name
+level-name=World=1
+`;
+      fs.existsSync.mockReturnValue(true);
+      fs.promises.readFile.mockResolvedValue(mockProperties);
+      backend.init({ serverDirectory: '/test/server' });
+
+      const properties = await backend.readServerProperties();
+
+      expect(properties).toEqual({
+        'server-name': 'My=Server=Name',
+        'level-name': 'World=1',
+      });
+    });
   });
 
   describe('readGlobalConfig', () => {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -161,7 +161,10 @@
                         'block-network-ids-are-hashes': ['true', 'false'],
                         'script-debugger-auto-attach': ['true', 'false'],
                         'pvp': ['true', 'false'],
-                        'hardcore': ['true', 'false']
+                        'hardcore': ['true', 'false'],
+                        'correct-player-movement': ['true', 'false'],
+                        'server-authoritative-movement': ['client-auth', 'server-auth', 'server-auth-with-rewind'],
+                        'allow-spectators': ['true', 'false']
                     };
                     for (const key in properties) {
                         const isDropdown = dropdownProperties.hasOwnProperty(key);


### PR DESCRIPTION
This PR addresses a bug where Minecraft server properties containing equals signs were being truncated during parsing. It also enhances the server manager UI with additional configuration options for modern Bedrock Dedicated Servers and ensures that configuration changes are applied to the backend state immediately without requiring a restart.

Key changes:
- Robust parsing of `server.properties` with support for values containing `=` and CRLF/LF line endings.
- Support for `allowlist.json` preservation during server updates.
- Real-time synchronization of global configuration changes.
- Additional configuration properties exposed in the web interface as user-friendly dropdowns.
- Regression tests for property parsing logic.

---
*PR created automatically by Jules for task [7220560928854685982](https://jules.google.com/task/7220560928854685982) started by @brettfxio*