### PR TITLE
Enhance Log Management and Refactor Pack Extraction

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import path, { dirname, join as pathJoin } from 'path';
+import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import multer from 'multer';
 import * as fs from 'fs';
@@ -10,7 +10,7 @@ const __filenameESM = fileURLToPath(import.meta.url);
 const __dirnameESM = dirname(__filenameESM);
 
 // Ensure temp directory for uploads exists
-const TEMP_UPLOAD_DIR = pathJoin(__dirnameESM, 'temp_uploads');
+const TEMP_UPLOAD_DIR = path.join(__dirnameESM, 'temp_uploads');
 if (!fs.existsSync(TEMP_UPLOAD_DIR)) {
     fs.mkdirSync(TEMP_UPLOAD_DIR, { recursive: true });
 }
@@ -48,11 +48,11 @@ const upload = multer({
 // Middleware
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use(express.static(pathJoin(__dirnameESM, 'public')));
+app.use(express.static(path.join(__dirnameESM, 'public')));
 
 // EJS Setup
 app.set('view engine', 'ejs');
-app.set('views', pathJoin(__dirnameESM, 'views'));
+app.set('views', path.join(__dirnameESM, 'views'));
 
 // --- Input Validation Middleware ---
 const validateWorldName = (req, res, next) => {
@@ -224,10 +224,26 @@ app.post('/api/logs/clear', async (req, res) => {
     }
 });
 
+app.get('/api/logs/download', async (req, res) => {
+    try {
+        const config = await backend.readGlobalConfig();
+        const serverLogPath = path.join(config.serverDirectory, 'server.log');
+
+        if (!fs.existsSync(serverLogPath)) {
+            return res.status(404).send('Server log file not found.');
+        }
+
+        res.download(serverLogPath, 'server.log');
+    } catch (error) {
+        backend.log('ERROR', `Error downloading server logs: ${error.message}`);
+        res.status(500).send('Failed to download server logs');
+    }
+});
+
 app.get('/api/logs', async (req, res) => {
     try {
         const config = await backend.readGlobalConfig();
-        const serverLogPath = pathJoin(config.serverDirectory, 'server.log');
+        const serverLogPath = path.join(config.serverDirectory, 'server.log');
 
         if (!fs.existsSync(serverLogPath)) {
             return res.json({ success: true, logs: 'Server log file not found. Start the server to generate logs.' });

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -1001,6 +1001,63 @@ async function updateWorldPackJson(worldPath, packTypeJsonFile, packId, packVers
 }
 
 /**
+ * Helper to extract specific entries from a ZIP (pack) to a target directory, with Zip Slip protection.
+ * @param {Array} zipEntries - All entries in the ZIP file.
+ * @param {string} packRootInZip - The relative path within the ZIP that acts as the root for this pack.
+ * @param {string} finalPackPath - The absolute path on the filesystem where files should be extracted.
+ * @param {Array<string>} allPackRootsInZip - Optional. All identified pack roots in the ZIP (used for .mcaddon to avoid cross-pack extraction).
+ */
+function extractPackEntries(zipEntries, packRootInZip, finalPackPath, allPackRootsInZip = []) {
+    const resolvedFinalPackPath = path.resolve(finalPackPath) + path.sep;
+
+    zipEntries.forEach(zipEntry => {
+        if (zipEntry.isDirectory) return;
+
+        let isEntryInPack = false;
+        let relativePathInPack = '';
+
+        if (packRootInZip === '') {
+            // If this pack is at the root, it owns all files EXCEPT those that belong to other packs
+            // (which are in subdirectories identified as pack roots).
+            const entryName = zipEntry.entryName;
+            const belongsToOtherPack = allPackRootsInZip.some(otherRoot => {
+                if (otherRoot === '') return false; // Don't compare with self
+                return entryName.startsWith(otherRoot + '/');
+            });
+
+            if (!belongsToOtherPack) {
+                isEntryInPack = true;
+                relativePathInPack = entryName;
+            }
+        } else {
+            // If this pack is in a subdirectory, it owns everything under that prefix
+            const prefix = packRootInZip + '/';
+            if (zipEntry.entryName.startsWith(prefix)) {
+                isEntryInPack = true;
+                relativePathInPack = path.relative(packRootInZip, zipEntry.entryName);
+            }
+        }
+
+        if (isEntryInPack && relativePathInPack) {
+            const targetFilePath = path.join(finalPackPath, relativePathInPack);
+
+            // Security: Check for Zip Slip vulnerability
+            const resolvedTargetFilePath = path.resolve(targetFilePath);
+            if (!resolvedTargetFilePath.startsWith(resolvedFinalPackPath)) {
+                log('WARNING', `Zip Slip attempt detected in pack: ${zipEntry.entryName}`);
+                return; // Skip this entry
+            }
+
+            const targetFileDir = path.dirname(targetFilePath);
+            if (!fs.existsSync(targetFileDir)) {
+                fs.mkdirSync(targetFileDir, { recursive: true });
+            }
+            fs.writeFileSync(targetFilePath, zipEntry.getData());
+        }
+    });
+}
+
+/**
  * Uploads and applies a pack (or packs from an addon) to a specific world.
  * @param {string} tempFilePath - Path to the temporary uploaded file (.mcpack or .mcaddon).
  * @param {string} originalFilename - The original name of the uploaded file.
@@ -1098,52 +1155,7 @@ export async function uploadPack(tempFilePath, originalFilename, requestedPackTy
                 }
                 fs.mkdirSync(finalPackPath, { recursive: true });
 
-                zipEntries.forEach(zipEntry => {
-                    if (zipEntry.isDirectory) return;
-
-                    let isEntryInPack = false;
-                    let relativePathInPack = '';
-
-                    if (packRootInZip === '') {
-                        // If this pack is at the root, it owns all files EXCEPT those that belong to other packs
-                        // (which are in subdirectories identified as pack roots).
-                        const entryName = zipEntry.entryName;
-                        const belongsToOtherPack = allPackRoots.some(otherRoot => {
-                            if (otherRoot === '') return false; // Don't compare with self
-                            return entryName.startsWith(otherRoot + '/');
-                        });
-
-                        if (!belongsToOtherPack) {
-                            isEntryInPack = true;
-                            relativePathInPack = entryName;
-                        }
-                    } else {
-                        // If this pack is in a subdirectory, it owns everything under that prefix
-                        const prefix = packRootInZip + '/';
-                        if (zipEntry.entryName.startsWith(prefix)) {
-                            isEntryInPack = true;
-                            relativePathInPack = path.relative(packRootInZip, zipEntry.entryName);
-                        }
-                    }
-
-                    if (isEntryInPack && relativePathInPack) {
-                        const targetFilePath = path.join(finalPackPath, relativePathInPack);
-
-                        // Security: Check for Zip Slip vulnerability
-                        const resolvedTargetFilePath = path.resolve(targetFilePath);
-                        const resolvedFinalPackPath = path.resolve(finalPackPath) + path.sep;
-                        if (!resolvedTargetFilePath.startsWith(resolvedFinalPackPath)) {
-                            log('WARNING', `Zip Slip attempt detected in .mcaddon: ${zipEntry.entryName}`);
-                            return; // Skip this entry
-                        }
-
-                        const targetFileDir = path.dirname(targetFilePath);
-                        if (!fs.existsSync(targetFileDir)) {
-                            fs.mkdirSync(targetFileDir, { recursive: true });
-                        }
-                        fs.writeFileSync(targetFilePath, zipEntry.getData());
-                    }
-                });
+                extractPackEntries(zipEntries, packRootInZip, finalPackPath, allPackRoots);
                 log('INFO', `Extracted pack '${packName}' to ${finalPackPath}`);
 
                 const updateSuccess = await updateWorldPackJson(worldPath, currentWorldPackJsonFile, packId, packVersion);
@@ -1236,41 +1248,7 @@ export async function uploadPack(tempFilePath, originalFilename, requestedPackTy
             }
             fs.mkdirSync(finalPackPath, { recursive: true });
 
-            zipEntries.forEach(zipEntry => {
-                if (zipEntry.isDirectory) return;
-
-                let isEntryInPack = false;
-                let relativePathInPack = '';
-
-                if (packRootInZip === '') {
-                    isEntryInPack = true;
-                    relativePathInPack = zipEntry.entryName;
-                } else {
-                    const prefix = packRootInZip + '/';
-                    if (zipEntry.entryName.startsWith(prefix)) {
-                        isEntryInPack = true;
-                        relativePathInPack = path.relative(packRootInZip, zipEntry.entryName);
-                    }
-                }
-
-                if (isEntryInPack && relativePathInPack) {
-                    const targetFilePath = path.join(finalPackPath, relativePathInPack);
-
-                    // Security: Check for Zip Slip vulnerability
-                    const resolvedTargetFilePath = path.resolve(targetFilePath);
-                    const resolvedFinalPackPath = path.resolve(finalPackPath) + path.sep;
-                    if (!resolvedTargetFilePath.startsWith(resolvedFinalPackPath)) {
-                        log('WARNING', `Zip Slip attempt detected in .mcpack: ${zipEntry.entryName}`);
-                        return; // Skip this entry
-                    }
-
-                    const targetFileDir = path.dirname(targetFilePath);
-                    if (!fs.existsSync(targetFileDir)) {
-                        fs.mkdirSync(targetFileDir, { recursive: true });
-                    }
-                    fs.writeFileSync(targetFilePath, zipEntry.getData());
-                }
-            });
+            extractPackEntries(zipEntries, packRootInZip, finalPackPath);
             log('INFO', `Extracted .mcpack '${packName}' to ${finalPackPath}`);
 
             const updateSuccess = await updateWorldPackJson(worldPath, worldPackJsonFile, packId, packVersion);

--- a/public/script.js
+++ b/public/script.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const restartButton = document.getElementById('restartButton');
     const updateButton = document.getElementById('updateButton');
     const clearLogsButton = document.getElementById('clearLogsButton');
+    const downloadLogsButton = document.getElementById('downloadLogsButton');
     const propertiesForm = document.getElementById('propertiesForm');
     const levelNameInput = document.getElementById('level-name'); // Get the level-name input
     const consoleOutput = document.getElementById('consoleOutput'); // Get the console textarea
@@ -417,6 +418,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     if (clearLogsButton) clearLogsButton.addEventListener('click', handleClearLogs);
+    if (downloadLogsButton) {
+        downloadLogsButton.addEventListener('click', () => {
+            showMessage('Log download initiated.', 'success');
+        });
+    }
     if (propertiesForm) propertiesForm.addEventListener('submit', saveServerProperties);
     if (autoUpdateConfigForm) autoUpdateConfigForm.addEventListener('submit', saveAutoUpdateConfig);
     if (uploadPackForm) {

--- a/public/style.css
+++ b/public/style.css
@@ -53,7 +53,7 @@ h1, h2 {
     gap: 10px;
     flex-wrap: wrap;
 }
-button {
+button, .button {
     background-color: #707070; /* Gray button */
     color: white;
     border: 2px solid #1E1E1E; /* Dark border */
@@ -62,6 +62,9 @@ button {
     font-size: 1rem;
     text-shadow: 2px 2px #373737;
     box-shadow: inset -2px -4px #0006, inset 2px 2px #FFF7;
+    display: inline-block;
+    text-align: center;
+    box-sizing: border-box;
 }
 button:hover {
     background-color: #A0A0A0; /* Lighter gray on hover */

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -22,15 +22,21 @@ jest.unstable_mockModule('../minecraft_bedrock_installer_nodejs.js', () => ({
 }));
 
 // Mock the fs module for app.js initialization
-jest.unstable_mockModule('fs', () => ({
+const mockFs = {
     existsSync: jest.fn().mockReturnValue(true), // Assume temp dir exists
     mkdirSync: jest.fn(),
-}));
+    promises: {
+        stat: jest.fn(),
+        open: jest.fn(),
+    }
+};
+jest.unstable_mockModule('fs', () => mockFs);
 
 
 // Dynamically import the app and the mocked backend after setup
 const { default: app } = await import('../app.js');
 const backend = await import('../minecraft_bedrock_installer_nodejs.js');
+const fs = await import('fs');
 
 describe('API Endpoints', () => {
 
@@ -93,6 +99,18 @@ describe('API Endpoints', () => {
 
         expect(res.statusCode).toEqual(500);
         expect(res.body).toEqual({ error: 'Failed to start server' });
+    });
+  });
+
+  describe('GET /api/logs/download', () => {
+    it('should return 404 if the log file does not exist', async () => {
+        backend.readGlobalConfig.mockResolvedValue({ serverDirectory: './non_existent' });
+        fs.existsSync.mockReturnValue(false);
+
+        const res = await request(app).get('/api/logs/download');
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.text).toEqual('Server log file not found.');
     });
   });
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -56,6 +56,7 @@
             <textarea id="consoleOutput" readonly placeholder="Server logs will appear here..."></textarea>
             <div class="button-group" style="margin-top: 10px;">
                 <button id="clearLogsButton" class="bg-gray-500 hover:bg-gray-700">Clear Logs</button>
+                <a href="/api/logs/download" id="downloadLogsButton" class="button no-underline" style="display: inline-block; text-decoration: none;">Download Full Log</a>
             </div>
         </div>
 


### PR DESCRIPTION
This PR introduces several enhancements and refactorings to the Bedrock Server Manager:

1. **Log Download Feature**: Users can now download the complete `server.log` file directly from the web interface. This is implemented via a new `/api/logs/download` endpoint in `app.js` and a corresponding button in the "Server Log" section of `index.ejs`.
2. **Refactored Pack Extraction**: The logic for extracting `.mcpack` and `.mcaddon` files in `minecraft_bedrock_installer_nodejs.js` has been refactored into a single, reusable `extractPackEntries` helper function. This reduces code duplication (DRY) and centralizes security checks like Zip Slip protection.
3. **Improved Consistency**: Standardized the use of `path.join()` in `app.js` and ensured consistent styling for the new download link.
4. **Enhanced Testing**: Added a new test case in `test/app.test.js` to verify the error handling of the log download endpoint.

All 21 tests passed, and frontend changes were visually verified with screenshots.

---
*PR created automatically by Jules for task [1500682218909598930](https://jules.google.com/task/1500682218909598930) started by @brettfxio*