### PR TITLE
Add Per-World Backups and Schema-Based Validation

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,21 +74,63 @@ const sanitizeServerProperties = (req, res, next) => {
     if (typeof properties !== 'object' || properties === null) {
         return res.status(400).json({ error: 'Invalid server properties format. Expected an object.' });
     }
+
+    const errors = [];
+
     for (const key in properties) {
         if (typeof key !== 'string' || key.match(/[\n\r]/)) {
             backend.log('ERROR', `Invalid character in server property key: ${key}`);
             return res.status(400).json({ error: `Invalid character in server property key: ${key}` });
         }
-        const value = properties[key];
+
+        let value = properties[key];
+
+        // Basic character validation
         if (typeof value === 'string' && value.match(/[\n\r]/)) {
             backend.log('ERROR', `Invalid character in server property value for key: ${key}`);
             return res.status(400).json({ error: `Invalid character in server property value for key: ${key}` });
         }
-        if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
-            properties[key] = String(value);
+
+        // Schema-based validation
+        const meta = propertiesMetadata[key];
+        if (meta) {
+            if (meta.type === 'number') {
+                const numValue = Number(value);
+                if (isNaN(numValue)) {
+                    errors.push(`Property '${meta.label || key}' must be a number.`);
+                } else {
+                    if (meta.min !== undefined && numValue < meta.min) {
+                        errors.push(`Property '${meta.label || key}' must be at least ${meta.min}.`);
+                    }
+                    if (meta.max !== undefined && numValue > meta.max) {
+                        errors.push(`Property '${meta.label || key}' must be no more than ${meta.max}.`);
+                    }
+                    properties[key] = String(numValue); // Keep as string for storage
+                }
+            } else if (meta.type === 'boolean') {
+                if (typeof value === 'boolean') {
+                    properties[key] = value ? 'true' : 'false';
+                } else if (value !== 'true' && value !== 'false') {
+                    errors.push(`Property '${meta.label || key}' must be a boolean.`);
+                }
+            } else if (meta.type === 'select') {
+                if (meta.options && !meta.options.includes(value)) {
+                    errors.push(`Property '${meta.label || key}' must be one of: ${meta.options.join(', ')}.`);
+                }
+            }
+        }
+
+        // Final type safety
+        if (typeof properties[key] !== 'string' && typeof properties[key] !== 'number' && typeof properties[key] !== 'boolean') {
+            properties[key] = String(properties[key]);
             backend.log('WARNING', `Property value for key '${key}' was converted to string.`);
         }
     }
+
+    if (errors.length > 0) {
+        return res.status(400).json({ error: 'Validation failed', details: errors });
+    }
+
     req.body = properties;
     next();
 };
@@ -277,6 +319,21 @@ app.post('/api/activate-world', validateWorldName, async (req, res) => {
     }
 });
 
+app.post('/api/backup-world', validateWorldName, async (req, res) => {
+    try {
+        const { worldName } = req.body;
+        const backupDir = await backend.backupWorld(worldName);
+        if (backupDir) {
+            res.json({ success: true, message: `Backup for world '${worldName}' created in: ${backupDir}` });
+        } else {
+            res.status(500).json({ success: false, message: `Failed to create backup for world '${worldName}'.` });
+        }
+    } catch (error) {
+        backend.log('ERROR', `Failed to backup world: ${error.message}`);
+        res.status(500).json({ success: false, message: 'Failed to create world backup due to server error.' });
+    }
+});
+
 app.get('/api/config', async (req, res) => {
     try {
         const appConfig = await backend.readGlobalConfig();
@@ -303,7 +360,7 @@ app.post('/api/logs/clear', async (req, res) => {
 
 app.get('/api/logs', async (req, res) => {
     try {
-        const config = await backend.readGlobalConfig();
+        const config = backend.getConfig();
         const serverLogPath = path.join(config.serverDirectory, 'server.log');
 
         if (!fs.existsSync(serverLogPath)) {
@@ -338,7 +395,7 @@ app.get('/api/logs', async (req, res) => {
 
 app.get('/api/logs/download', async (req, res) => {
     try {
-        const config = await backend.readGlobalConfig();
+        const config = backend.getConfig();
         const serverLogPath = path.join(config.serverDirectory, 'server.log');
 
         if (!fs.existsSync(serverLogPath)) {
@@ -478,7 +535,7 @@ app.post('/api/upload-pack', upload.single('packFile'), async (req, res) => {
 // --- Frontend Routes ---
 app.get('/', async (req, res) => {
     try {
-        const currentConfig = await backend.readGlobalConfig();
+        const currentConfig = backend.getConfig();
         const properties = await backend.readServerProperties();
         const worlds = await backend.listWorlds();
         const isRunning = await backend.isProcessRunning();

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -89,6 +89,14 @@ export function isValidWorldName(worldName) {
     return true;
 }
 
+/**
+ * Returns the current configuration from memory.
+ * @returns {object} The current configuration.
+ */
+export function getConfig() {
+    return config;
+}
+
 export function getServerExeName() {
     const platform = os.platform();
     const serverType = config.serverType || 'bedrock';
@@ -303,6 +311,49 @@ export async function changeOwnership(dirPath, user, group) {
         });
     } catch (error) {
         log('ERROR', `Error during changeOwnership setup for ${dirPath}: ${error.message}`);
+        throw error;
+    }
+}
+
+/**
+ * Backs up a specific world directory.
+ * @param {string} worldName - The name of the world to backup.
+ * @returns {Promise<string|null>} The path to the backup directory, or null if failed.
+ */
+export async function backupWorld(worldName) {
+    if (!SERVER_DIRECTORY || !fs.existsSync(SERVER_DIRECTORY)) {
+        log('ERROR', 'SERVER_DIRECTORY not set. Cannot backup world.');
+        return null;
+    }
+    if (!isValidWorldName(worldName)) {
+        log('ERROR', `Invalid world name for backup: ${worldName}`);
+        return null;
+    }
+
+    const worldPath = path.join(SERVER_DIRECTORY, 'worlds', worldName);
+    if (!fs.existsSync(worldPath)) {
+        log('ERROR', `World directory '${worldName}' not found at ${worldPath}.`);
+        return null;
+    }
+
+    const backupSubDir = `world_${worldName}_${new Date().toISOString().replace(/:/g, '-').replace(/\./g, '_')}`;
+    const backupDir = path.join(BACKUP_DIRECTORY, backupSubDir);
+
+    try {
+        fs.mkdirSync(backupDir, { recursive: true });
+        log('INFO', `Creating backup for world '${worldName}' in ${backupDir}`);
+        fs.cpSync(worldPath, path.join(backupDir, worldName), { recursive: true });
+
+        if (os.platform() !== 'win32') {
+            await changeOwnership(backupDir, config.minecraftUser, config.minecraftGroup);
+        }
+        log('INFO', `World backup complete: ${backupDir}`);
+        return backupDir;
+    } catch (error) {
+        log('ERROR', `Error during world backup for '${worldName}': ${error.message}`);
+        if (fs.existsSync(backupDir)) {
+            fs.rmSync(backupDir, { recursive: true, force: true });
+        }
         throw error;
     }
 }
@@ -1035,6 +1086,7 @@ export async function readGlobalConfig() {
         try { fs.writeFileSync(configPath, JSON.stringify(effectiveConfig, null, 2), 'utf8'); log('INFO', `Created default configuration file at ${configPath}`); }
         catch (writeError) { log('ERROR', `Failed to create default configuration file at ${configPath}: ${writeError.message}`); }
     }
+    config = effectiveConfig;
     const args = process.argv.slice(2);
     log('DEBUG', `CLI arguments: ${args.join(' ')}`);
     for (let i = 0; i < args.length; i++) {
@@ -1067,6 +1119,12 @@ export async function readGlobalConfig() {
     effectiveConfig.serverDirectory = resolvePath(effectiveConfig.serverDirectory);
     effectiveConfig.tempDirectory = resolvePath(effectiveConfig.tempDirectory);
     effectiveConfig.backupDirectory = resolvePath(effectiveConfig.backupDirectory);
+
+    config = effectiveConfig;
+    SERVER_DIRECTORY = config.serverDirectory;
+    TEMP_DIRECTORY = config.tempDirectory;
+    BACKUP_DIRECTORY = config.backupDirectory;
+
     log('INFO', 'Configuration loading complete.');
     log('DEBUG', `Final effective configuration: ${JSON.stringify(effectiveConfig, null, 2)}`);
     return effectiveConfig;

--- a/public/script.js
+++ b/public/script.js
@@ -362,7 +362,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Refresh worlds list if level-name changed
                 loadWorlds();
             } else {
-                showMessage('Failed to save server properties: ' + data.message, 'error');
+                const errorMsg = data.details ? `${data.error}: ${data.details.join(' ')}` : (data.message || data.error || 'Unknown error');
+                showMessage('Failed to save server properties: ' + errorMsg, 'error');
             }
         } catch (error) {
             console.error('Error saving server properties:', error);
@@ -394,6 +395,9 @@ document.addEventListener('DOMContentLoaded', () => {
                                 <button class="activate-world-button bg-blue-500 hover:bg-blue-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Activate
                                 </button>
+                                <button class="backup-world-button bg-green-600 hover:bg-green-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
+                                    Backup
+                                </button>
                                 ${currentLevelName !== world ? `
                                 <button class="delete-world-button bg-red-500 hover:bg-red-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Delete
@@ -403,6 +407,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             worldListContainer.appendChild(worldItem);
                         });
                         addActivateButtonListeners(); // Re-add listeners after updating DOM
+                        addBackupButtonListeners(); // Re-add listeners after updating DOM
                         addDeleteButtonListeners(); // Re-add listeners after updating DOM
                     } else {
                         worldListContainer.innerHTML = '<p class="text-gray-600">No worlds found. Start the server to generate a default world.</p>';
@@ -423,6 +428,13 @@ document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('.activate-world-button').forEach(button => {
             button.removeEventListener('click', handleActivateWorldClick); // Prevent duplicate listeners
             button.addEventListener('click', handleActivateWorldClick);
+        });
+    }
+
+    function addBackupButtonListeners() {
+        document.querySelectorAll('.backup-world-button').forEach(button => {
+            button.removeEventListener('click', handleBackupWorldClick); // Prevent duplicate listeners
+            button.addEventListener('click', handleBackupWorldClick);
         });
     }
 
@@ -487,6 +499,29 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (error) {
             console.error('Error creating world:', error);
             showMessage('Failed to create world.', 'error');
+        }
+    }
+
+    async function handleBackupWorldClick(event) {
+        const worldName = event.target.dataset.worldName;
+        try {
+            showMessage(`Creating backup for world '${worldName}'...`);
+            const response = await fetch('/api/backup-world', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ worldName })
+            });
+            const data = await response.json();
+            if (response.ok && data.success) {
+                showMessage(data.message || `Backup for world '${worldName}' created.`, 'success');
+            } else {
+                showMessage(data.message || `Failed to backup world '${worldName}'.`, 'error');
+            }
+        } catch (error) {
+            console.error('Error backing up world:', error);
+            showMessage('Failed to backup world.', 'error');
         }
     }
 
@@ -720,6 +755,7 @@ document.addEventListener('DOMContentLoaded', () => {
     //loadWorlds();
     loadAutoUpdateConfig(); // New: Load auto-update config on page load
     addActivateButtonListeners();
+    addBackupButtonListeners();
     addDeleteButtonListeners();
     fetchLogs();
     fetchSystemInfo();

--- a/test/config_and_backup.test.js
+++ b/test/config_and_backup.test.js
@@ -1,0 +1,90 @@
+import { jest } from '@jest/globals';
+import * as fs from 'fs';
+import path from 'path';
+import os from 'os';
+import request from 'supertest';
+import app from '../app.js';
+import * as backend from '../minecraft_bedrock_installer_nodejs.js';
+
+describe('Configuration Caching and World Backup Tests', () => {
+    let testDir;
+    let serverDir;
+    let backupDir;
+
+    beforeAll(() => {
+        testDir = path.join(os.tmpdir(), `config-backup-test-${Math.random().toString(36).substring(7)}`);
+        serverDir = path.join(testDir, 'server');
+        backupDir = path.join(testDir, 'backup');
+
+        fs.mkdirSync(serverDir, { recursive: true });
+        fs.mkdirSync(backupDir, { recursive: true });
+        fs.mkdirSync(path.join(serverDir, 'worlds', 'test_world'), { recursive: true });
+        fs.writeFileSync(path.join(serverDir, 'server.properties'), 'level-name=test_world\nserver-port=19132', 'utf8');
+
+        backend.init({
+            serverDirectory: serverDir,
+            backupDirectory: backupDir,
+            logLevel: 'DEBUG'
+        });
+    });
+
+    afterAll(() => {
+        fs.rmSync(testDir, { recursive: true, force: true });
+    });
+
+    test('getConfig should return the current configuration from memory', () => {
+        const config = backend.getConfig();
+        expect(config).toBeDefined();
+        expect(config.serverDirectory).toBe(serverDir);
+    });
+
+    test('backupWorld should create a backup of a specific world', async () => {
+        const resultDir = await backend.backupWorld('test_world');
+        expect(resultDir).toBeDefined();
+        expect(fs.existsSync(resultDir)).toBe(true);
+        expect(fs.existsSync(path.join(resultDir, 'test_world'))).toBe(true);
+    });
+
+    test('POST /api/backup-world should trigger world backup', async () => {
+        const response = await request(app)
+            .post('/api/backup-world')
+            .send({ worldName: 'test_world' });
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(response.body.message).toContain('Backup for world \'test_world\' created');
+    });
+
+    test('POST /api/properties should validate numeric ranges', async () => {
+        const response = await request(app)
+            .post('/api/properties')
+            .send({ 'server-port': 70000 }); // Out of range (max 65535)
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe('Validation failed');
+        expect(response.body.details).toContain("Property 'IPv4 Port' must be no more than 65535.");
+    });
+
+    test('POST /api/properties should validate select options', async () => {
+        const response = await request(app)
+            .post('/api/properties')
+            .send({ 'gamemode': 'invalid_mode' });
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe('Validation failed');
+        expect(response.body.details).toContain("Property 'Default Game Mode' must be one of: survival, creative, adventure.");
+    });
+
+    test('POST /api/properties should accept valid values', async () => {
+        const response = await request(app)
+            .post('/api/properties')
+            .send({ 'server-port': 19133, 'gamemode': 'creative' });
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+
+        const properties = await backend.readServerProperties();
+        expect(properties['server-port']).toBe('19133');
+        expect(properties['gamemode']).toBe('creative');
+    });
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -108,6 +108,9 @@
                             <button class="activate-world-button" data-world-name="<%= world %>">
                                 Activate
                             </button>
+                            <button class="backup-world-button bg-green-600 hover:bg-green-700" data-world-name="<%= world %>">
+                                Backup
+                            </button>
                             <% if (properties['level-name'] !== world) { %>
                                 <button class="delete-world-button bg-red-500 hover:bg-red-700" data-world-name="<%= world %>">
                                     Delete


### PR DESCRIPTION
Implemented a per-world backup system allowing users to create timestamped copies of specific worlds via the UI. Enhanced server property validation by enforcing type, range, and enumeration constraints based on the metadata schema. Optimized the application by caching global configuration in memory to avoid frequent disk reads during log polling and status checks. Added comprehensive unit tests for the new functionality.

---
*PR created automatically by Jules for task [12137097034780257486](https://jules.google.com/task/12137097034780257486) started by @brettfxio*