### PR TITLE
Enhance server management: graceful shutdown, backup management, and player list

### DIFF
--- a/app.js
+++ b/app.js
@@ -146,6 +146,16 @@ app.get('/api/status', async (req, res) => {
     }
 });
 
+app.get('/api/players', async (req, res) => {
+    try {
+        const playersInfo = await backend.getOnlinePlayers();
+        res.json({ success: true, ...playersInfo });
+    } catch (error) {
+        backend.log('ERROR', `Error getting online players: ${error.message}`);
+        res.status(500).json({ success: false, error: 'Failed to get online players' });
+    }
+});
+
 app.get('/api/system-info', async (req, res) => {
     try {
         const info = {
@@ -226,6 +236,31 @@ app.post('/api/backup', async (req, res) => {
     } catch (error) {
         backend.log('ERROR', `Failed to create manual backup: ${error.message}`);
         res.status(500).json({ success: false, message: 'Failed to create manual backup due to server error.' });
+    }
+});
+
+app.get('/api/backups', async (req, res) => {
+    try {
+        const backups = await backend.listBackups();
+        res.json({ success: true, backups });
+    } catch (error) {
+        backend.log('ERROR', `Failed to list backups: ${error.message}`);
+        res.status(500).json({ success: false, message: 'Failed to list backups.' });
+    }
+});
+
+app.delete('/api/backups/:backupName', async (req, res) => {
+    try {
+        const { backupName } = req.params;
+        const result = await backend.deleteBackup(backupName);
+        if (result.success) {
+            res.json(result);
+        } else {
+            res.status(400).json(result);
+        }
+    } catch (error) {
+        backend.log('ERROR', `Failed to delete backup: ${error.message}`);
+        res.status(500).json({ success: false, message: 'Failed to delete backup.' });
     }
 });
 

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -316,6 +316,58 @@ export async function changeOwnership(dirPath, user, group) {
 }
 
 /**
+ * Lists all available backups in the backup directory.
+ * @returns {Promise<Array<string>>} A list of backup directory names.
+ */
+export async function listBackups() {
+    if (!BACKUP_DIRECTORY || !fs.existsSync(BACKUP_DIRECTORY)) {
+        log('WARNING', 'BACKUP_DIRECTORY not set or not found. Cannot list backups.');
+        return [];
+    }
+    try {
+        const entries = await fs.promises.readdir(BACKUP_DIRECTORY, { withFileTypes: true });
+        const backups = entries
+            .filter(entry => entry.isDirectory())
+            .map(entry => entry.name)
+            .sort((a, b) => b.localeCompare(a)); // Sort latest first
+        log('INFO', `Listed ${backups.length} backups.`);
+        return backups;
+    } catch (error) {
+        log('ERROR', `Error listing backups: ${error.message}`);
+        return [];
+    }
+}
+
+/**
+ * Deletes a specific backup directory.
+ * @param {string} backupName - The name of the backup directory to delete.
+ * @returns {Promise<{success: boolean, message: string}>}
+ */
+export async function deleteBackup(backupName) {
+    if (!BACKUP_DIRECTORY) {
+        return { success: false, message: 'Backup directory not configured.' };
+    }
+    // Simple validation to prevent directory traversal
+    if (backupName.includes('..') || backupName.includes('/') || backupName.includes('\\')) {
+        return { success: false, message: 'Invalid backup name.' };
+    }
+
+    const targetBackupPath = path.join(BACKUP_DIRECTORY, backupName);
+    if (!fs.existsSync(targetBackupPath)) {
+        return { success: false, message: 'Backup not found.' };
+    }
+
+    try {
+        await fs.promises.rm(targetBackupPath, { recursive: true, force: true });
+        log('INFO', `Deleted backup: ${backupName}`);
+        return { success: true, message: `Backup '${backupName}' deleted successfully.` };
+    } catch (error) {
+        log('ERROR', `Failed to delete backup '${backupName}': ${error.message}`);
+        return { success: false, message: `Failed to delete backup: ${error.message}` };
+    }
+}
+
+/**
  * Backs up a specific world directory.
  * @param {string} worldName - The name of the world to backup.
  * @returns {Promise<string|null>} The path to the backup directory, or null if failed.
@@ -472,15 +524,27 @@ export async function stopServer() {
     const pidToKill = serverPID;
     try {
         log('INFO', `Attempting to stop Minecraft server process with PID: ${pidToKill}.`);
-        process.kill(pidToKill, 'SIGTERM');
-        log('INFO', `SIGTERM signal sent to PID: ${pidToKill}.`);
+
+        // Attempt graceful shutdown via command if process is available
+        if (activeServerProcess && activeServerProcess.stdin && activeServerProcess.stdin.writable) {
+            log('INFO', 'Sending "stop" command for graceful shutdown.');
+            activeServerProcess.stdin.write('stop\n');
+        } else {
+            log('INFO', 'Server process stdin not available, falling back to SIGTERM.');
+            process.kill(pidToKill, 'SIGTERM');
+        }
 
         // Wait for process to exit
         let isRunning = true;
-        for (let i = 0; i < 50; i++) { // 5 seconds total
+        for (let i = 0; i < 100; i++) { // 10 seconds total for graceful shutdown
             try {
                 process.kill(pidToKill, 0);
                 await new Promise(resolve => setTimeout(resolve, 100));
+                // After 5 seconds, if still running, try SIGTERM if we didn't already
+                if (i === 50 && activeServerProcess && activeServerProcess.stdin && activeServerProcess.stdin.writable) {
+                    log('WARNING', 'Server did not stop via command after 5s. Sending SIGTERM.');
+                    process.kill(pidToKill, 'SIGTERM');
+                }
             } catch (e) {
                 isRunning = false;
                 break;
@@ -488,7 +552,7 @@ export async function stopServer() {
         }
 
         if (isRunning) {
-            log('WARNING', `Server process ${pidToKill} did not exit after 5 seconds. Sending SIGKILL.`);
+            log('WARNING', `Server process ${pidToKill} did not exit after 10 seconds. Sending SIGKILL.`);
             try {
                 process.kill(pidToKill, 'SIGKILL');
             } catch (e) {
@@ -502,7 +566,7 @@ export async function stopServer() {
         }
         log('INFO', `Server process ${pidToKill} stopped.`);
     } catch (error) {
-        log('ERROR', `Error stopping server with PID ${pidToKill} (process might not exist): ${error.message}`);
+        log('ERROR', `Error stopping server with PID ${pidToKill}: ${error.message}`);
     } finally {
         if (serverPID === pidToKill) {
             serverPID = null;
@@ -974,6 +1038,58 @@ export async function sendServerCommand(command) {
         log('ERROR', `Error sending console command: ${error.message}`);
         return { success: false, message: `Failed to send command: ${error.message}` };
     }
+}
+
+/**
+ * Gets the list of online players by parsing the 'list' command output.
+ * @returns {Promise<{count: number, max: number, players: Array<string>}>}
+ */
+export async function getOnlinePlayers() {
+    if (!activeServerProcess || !activeServerProcess.stdin || activeServerProcess.stdin.writable === false) {
+        return { count: 0, max: 0, players: [] };
+    }
+
+    return new Promise((resolve) => {
+        const command = 'list';
+        let output = '';
+
+        const onData = (data) => {
+            output += data.toString();
+            // Bedrock 'list' command typical output: "There are 1/20 players online: Player1, Player2"
+            if (output.includes('players online')) {
+                cleanup();
+                const result = parsePlayerList(output);
+                resolve(result);
+            }
+        };
+
+        const timeout = setTimeout(() => {
+            cleanup();
+            resolve({ count: 0, max: 0, players: [] });
+        }, 2000);
+
+        const cleanup = () => {
+            clearTimeout(timeout);
+            activeServerProcess.stdout.removeListener('data', onData);
+        };
+
+        activeServerProcess.stdout.on('data', onData);
+        activeServerProcess.stdin.write(command + '\n');
+    });
+}
+
+function parsePlayerList(output) {
+    // Example: "There are 1/20 players online:\nPlayer1"
+    // or "There are 0/20 players online:"
+    const match = output.match(/There are (\d+)\/(\d+) players online:?([\s\S]*)/);
+    if (match) {
+        const count = parseInt(match[1], 10);
+        const max = parseInt(match[2], 10);
+        const playersStr = match[3].trim();
+        const players = playersStr ? playersStr.split(/,\s*|\n/).map(p => p.trim()).filter(p => p) : [];
+        return { count, max, players };
+    }
+    return { count: 0, max: 0, players: [] };
 }
 
 export async function isProcessRunning() {

--- a/public/script.js
+++ b/public/script.js
@@ -13,6 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const propertiesTabs = document.getElementById('propertiesTabs');
     const consoleOutput = document.getElementById('consoleOutput'); // Get the console textarea
     const systemInfoContent = document.getElementById('systemInfoContent');
+    const playerInfoDiv = document.getElementById('playerInfo');
+    const playerCountSpan = document.getElementById('playerCount');
+    const maxPlayersSpan = document.getElementById('maxPlayers');
+    const playerListNamesP = document.getElementById('playerListNames');
 
     // Auto-Update specific elements
     const autoUpdateConfigForm = document.getElementById('autoUpdateConfigForm');
@@ -24,6 +28,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const newWorldNameInput = document.getElementById('newWorldName');
 
     const restartNeededNote = document.getElementById('restartNeededNote');
+
+    const backupListContainer = document.getElementById('backupList');
 
     // Pack Management specific elements
     const uploadPackForm = document.getElementById('uploadPackForm');
@@ -149,6 +155,11 @@ document.addEventListener('DOMContentLoaded', () => {
             const response = await fetch('/api/status');
             const data = await response.json();
             updateServerStatusDisplay(data.status);
+            if (data.status === 'running') {
+                fetchPlayerList();
+            } else {
+                if (playerInfoDiv) playerInfoDiv.style.display = 'none';
+            }
         } catch (error) {
             console.error('Error fetching server status:', error);
             updateServerStatusDisplay('unknown'); // Set status to unknown on error
@@ -557,6 +568,63 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Auto-Update Configuration Functions ---
+    async function loadBackups() {
+        if (!backupListContainer) return;
+        try {
+            const response = await fetch('/api/backups');
+            const data = await response.json();
+            if (data.success) {
+                backupListContainer.innerHTML = '';
+                if (data.backups && data.backups.length > 0) {
+                    data.backups.forEach(backup => {
+                        const backupItem = document.createElement('div');
+                        backupItem.className = 'world-item';
+                        backupItem.innerHTML = `
+                            <span>${backup}</span>
+                            <div class="button-group">
+                                <button class="delete-backup-button bg-red-500 hover:bg-red-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-backup-name="${backup}">
+                                    Delete
+                                </button>
+                            </div>
+                        `;
+                        backupListContainer.appendChild(backupItem);
+                    });
+                    addDeleteBackupButtonListeners();
+                } else {
+                    backupListContainer.innerHTML = '<p class="text-gray-600">No backups found.</p>';
+                }
+            }
+        } catch (error) {
+            console.error('Error loading backups:', error);
+        }
+    }
+
+    function addDeleteBackupButtonListeners() {
+        document.querySelectorAll('.delete-backup-button').forEach(button => {
+            button.addEventListener('click', handleDeleteBackupClick);
+        });
+    }
+
+    async function handleDeleteBackupClick(event) {
+        const backupName = event.target.dataset.backupName;
+        if (!confirm(`Are you sure you want to delete the backup '${backupName}'?`)) return;
+
+        try {
+            showMessage(`Deleting backup '${backupName}'...`);
+            const response = await fetch(`/api/backups/${backupName}`, { method: 'DELETE' });
+            const data = await response.json();
+            if (response.ok && data.success) {
+                showMessage(data.message, 'success');
+                loadBackups();
+            } else {
+                showMessage(data.message || 'Failed to delete backup.', 'error');
+            }
+        } catch (error) {
+            console.error('Error deleting backup:', error);
+            showMessage('Failed to delete backup.', 'error');
+        }
+    }
+
     async function loadAutoUpdateConfig() {
         try {
             const response = await fetch('/api/config');
@@ -714,6 +782,29 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    async function fetchPlayerList() {
+        if (!playerInfoDiv) return;
+        try {
+            const response = await fetch('/api/players');
+            const data = await response.json();
+            if (data.success) {
+                playerInfoDiv.style.display = 'block';
+                playerCountSpan.textContent = data.count;
+                maxPlayersSpan.textContent = data.max;
+                if (data.players && data.players.length > 0) {
+                    playerListNamesP.textContent = 'Players: ' + data.players.join(', ');
+                } else {
+                    playerListNamesP.textContent = '';
+                }
+            } else {
+                playerInfoDiv.style.display = 'none';
+            }
+        } catch (error) {
+            console.error('Error fetching player list:', error);
+            playerInfoDiv.style.display = 'none';
+        }
+    }
+
     async function fetchSystemInfo() {
         if (!systemInfoContent) return;
         try {
@@ -753,6 +844,7 @@ document.addEventListener('DOMContentLoaded', () => {
     fetchServerStatus(); // This will now also set initial button states
     loadServerProperties();
     //loadWorlds();
+    loadBackups();
     loadAutoUpdateConfig(); // New: Load auto-update config on page load
     addActivateButtonListeners();
     addBackupButtonListeners();
@@ -763,6 +855,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Refresh status and worlds periodically
     setInterval(fetchServerStatus, 10000); // Every 10 seconds
     setInterval(loadWorlds, 30000); // Every 30 seconds
+    setInterval(loadBackups, 60000); // Every minute
     setInterval(fetchLogs, 5000); // Every 5 seconds
     setInterval(fetchSystemInfo, 30000); // Every 30 seconds
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -40,6 +40,10 @@
             <div id="messageBox" class="message-box" role="alert" style="display: none;"></div>
             <h2>Server Status</h2>
             <p>Current Status: <span id="serverStatus" class="status-indicator status-<%= serverStatus %>"><%= serverStatus.toUpperCase() %></span></p>
+            <div id="playerInfo" style="margin-bottom: 10px; display: none;">
+                <p><strong>Players Online:</strong> <span id="playerCount">0</span> / <span id="maxPlayers">0</span></p>
+                <p id="playerListNames" style="font-size: 0.9em; color: #666;"></p>
+            </div>
             <% if (config.serverType === 'java') { %>
                 <p>Java server support is coming soon!</p>
                 <div class="button-group">
@@ -123,6 +127,14 @@
                 <% } %>
             </div>
             <p>To activate a world, click 'Activate' next to its name. <strong>Note: This will automatically update your server properties and restart the server to apply the change.</strong></p>
+        </div>
+
+        <div class="section">
+            <h2>Backup Management</h2>
+            <div id="backupList" class="world-list">
+                <p>Loading backups...</p>
+            </div>
+            <p>Backups include all server files (worlds, configurations, and packs). Deleting a backup is permanent.</p>
         </div>
 
         <div class="section">


### PR DESCRIPTION
This PR introduces several key enhancements to the Bedrock Server Manager:

1.  **Graceful Shutdown:** The `stopServer` logic now attempts to send a `stop` command to the server console first, ensuring data is saved before the process is terminated. It falls back to `SIGTERM` and `SIGKILL` only if necessary.
2.  **Backup Management:** Users can now view and delete server backups directly from the web interface. New API endpoints (`GET /api/backups`, `DELETE /api/backups/:name`) and a dedicated UI section were added.
3.  **Online Player List:** When the server is running, the dashboard now displays the current number of online players and their gamertags. This is achieved by parsing the output of the `list` command.

These features improve the usability and reliability of the manager, providing better visibility and control over the hosted Minecraft server.

---
*PR created automatically by Jules for task [9678910030392298500](https://jules.google.com/task/9678910030392298500) started by @brettfxio*