### PR TITLE
Convert frontend into PWA

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "Bedrock Server Manager",
+  "short_name": "BSM",
+  "description": "Web-based interface to manage a Minecraft Bedrock Dedicated Server",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#373737",
+  "theme_color": "#555555",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon.ico",
+      "sizes": "16x16 32x32",
+      "type": "image/x-icon"
+    }
+  ],
+  "screenshots": [
+    {
+      "src": "/mbsm-screen.PNG",
+      "sizes": "1019x840",
+      "type": "image/png",
+      "form_factor": "wide",
+      "label": "Bedrock Server Manager Desktop View"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,57 @@
+const CACHE_NAME = 'bsm-v2';
+const STATIC_ASSETS = [
+  '/style.css',
+  '/script.js',
+  '/favicon.ico',
+  '/icon.ico',
+  '/fonts/MinecraftBold-nMK1.otf',
+  '/fonts/MinecraftBoldItalic-1y1e.otf',
+  '/fonts/MinecraftItalic-R8Mo.otf',
+  '/fonts/MinecraftRegular-Bmg3.otf'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(STATIC_ASSETS);
+    })
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.filter((name) => name !== CACHE_NAME).map((name) => caches.delete(name))
+      );
+    })
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  // Network-first strategy for the root page and API calls
+  if (url.pathname === '/' || url.pathname.startsWith('/api/')) {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          // Optionally cache the latest response for offline viewing
+          return caches.open(CACHE_NAME).then((cache) => {
+            cache.put(event.request, response.clone());
+            return response;
+          });
+        })
+        .catch(() => {
+          return caches.match(event.request);
+        })
+    );
+  } else {
+    // Cache-first strategy for static assets
+    event.respondWith(
+      caches.match(event.request).then((response) => {
+        return response || fetch(event.request);
+      })
+    );
+  }
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bedrock Server Manager</title>
     <link href="/style.css" rel="stylesheet">
+    <link rel="manifest" href="/manifest.json">
+    <meta name="theme-color" content="#555555">
+    <link rel="apple-touch-icon" href="/favicon.ico">
 </head>
 <body>
     <div class="container">
@@ -177,5 +180,14 @@
     </div>
 
     <script src="/script.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/sw.js')
+                    .then(reg => console.log('Service Worker registered', reg))
+                    .catch(err => console.error('Service Worker registration failed', err));
+            });
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Converted the Bedrock Server Manager frontend into a Progressive Web App (PWA). This includes adding a web app manifest for installability and a service worker for basic offline support and improved loading times. The service worker uses a Network-first strategy for the dashboard and API calls to ensure real-time data accuracy, and a Cache-first strategy for static assets.

---
*PR created automatically by Jules for task [9628603697828862857](https://jules.google.com/task/9628603697828862857) started by @brettfxio*