### PR TITLE
Implement World Renaming and UI Improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -342,6 +342,27 @@ app.post('/api/delete-world', validateWorldName, async (req, res) => {
     }
 });
 
+app.post('/api/rename-world', async (req, res) => {
+    try {
+        const { oldWorldName, newWorldName } = req.body;
+        if (!oldWorldName || !newWorldName) {
+            return res.status(400).json({ success: false, message: 'Both old and new world names are required.' });
+        }
+        if (!backend.isValidWorldName(oldWorldName) || !backend.isValidWorldName(newWorldName)) {
+            return res.status(400).json({ success: false, message: 'Invalid world name format.' });
+        }
+        const result = await backend.renameWorld(oldWorldName, newWorldName);
+        if (result.success) {
+            res.json(result);
+        } else {
+            res.status(400).json(result);
+        }
+    } catch (error) {
+        backend.log('ERROR', `Failed to rename world: ${error.message}`);
+        res.status(500).json({ success: false, message: 'Failed to rename world due to server error.' });
+    }
+});
+
 app.post('/api/activate-world', validateWorldName, async (req, res) => {
     try {
         const { worldName } = req.body;

--- a/docs/API.html
+++ b/docs/API.html
@@ -114,6 +114,25 @@
 <li><code>500 Internal Server Error</code>: <code>{ &quot;error&quot;: &quot;Failed to restart server&quot; }</code></li>
 </ul>
 <hr>
+<h3>GET /api/players</h3>
+<p>Retrieves the number of online players and their gamertags.</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;count&quot;: number, &quot;max&quot;: number, &quot;players&quot;: [&quot;player1&quot;, ...] }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;error&quot;: &quot;Failed to get players&quot; }</code></li>
+</ul>
+<hr>
+<h3>POST /api/command</h3>
+<p>Sends a console command to the Minecraft server.</p>
+<p><strong>Request Body:</strong>
+<code>{ &quot;command&quot;: &quot;string&quot; }</code></p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: string }</code></li>
+<li><code>400 Bad Request</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
 <h3>POST /api/update</h3>
 <p>Checks for Minecraft server updates and installs them if available. This involves stopping the server, backing up data, downloading the new version, restoring data, and restarting the server.</p>
 <p><strong>Response:</strong></p>
@@ -142,6 +161,13 @@ JSON object containing the property keys and values to update.</p>
 <li><code>500 Internal Server Error</code>: <code>{ &quot;error&quot;: &quot;Failed to write server properties&quot; }</code></li>
 </ul>
 <hr>
+<h3>GET /api/properties/metadata</h3>
+<p>Retrieves metadata for server properties, including human-readable labels, categories, and descriptions.</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;metadata&quot;: { ... }, &quot;categories&quot;: [ ... ] }</code></li>
+</ul>
+<hr>
 <h2>World Management</h2>
 <h3>GET /api/worlds</h3>
 <p>Lists all world folders found in the server’s <code>worlds</code> directory.</p>
@@ -160,6 +186,121 @@ JSON object containing the property keys and values to update.</p>
 <li><code>200 OK</code>: <code>{ &quot;message&quot;: &quot;World 'worldName' activated.&quot; }</code></li>
 <li><code>400 Bad Request</code>: <code>{ &quot;error&quot;: string }</code> (if world name is missing or invalid)</li>
 <li><code>500 Internal Server Error</code>: <code>{ &quot;error&quot;: &quot;Failed to activate world&quot; }</code></li>
+</ul>
+<hr>
+<h3>POST /api/create-world</h3>
+<p>Creates a new empty world directory.</p>
+<p><strong>Request Body:</strong>
+<code>{ &quot;worldName&quot;: &quot;string&quot; }</code></p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: string }</code></li>
+<li><code>400 Bad Request</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
+<h3>POST /api/rename-world</h3>
+<p>Renames an existing world directory. If the renamed world is the currently active one, the <code>level-name</code> in <code>server.properties</code> will be automatically updated.</p>
+
+<p><strong>Request Body:</strong>
+<code>{ &quot;oldWorldName&quot;: &quot;string&quot;, &quot;newWorldName&quot;: &quot;string&quot; }</code></p>
+
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: string }</code></li>
+<li><code>400 Bad Request</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
+<h3>POST /api/delete-world</h3>
+<p>Deletes a world directory. The currently active world cannot be deleted.</p>
+<p><strong>Request Body:</strong>
+<code>{ &quot;worldName&quot;: &quot;string&quot; }</code></p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: string }</code></li>
+<li><code>400 Bad Request</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
+<h3>POST /api/backup-world</h3>
+<p>Creates a backup of a specific world.</p>
+<p><strong>Request Body:</strong>
+<code>{ &quot;worldName&quot;: &quot;string&quot; }</code></p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: string }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
+<h3>POST /api/upload-world</h3>
+<p>Uploads and extracts a world from a <code>.mcworld</code> file.</p>
+<p><strong>Request Type:</strong> <code>multipart/form-data</code></p>
+<p><strong>Parameters:</strong></p>
+<ul>
+<li><code>worldFile</code>: The <code>.mcworld</code> file.</li>
+</ul>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: string, &quot;worldName&quot;: string }</code></li>
+<li><code>400 Bad Request</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
+<h2>Backup Management</h2>
+<h3>GET /api/backups</h3>
+<p>Lists all manual server backups.</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;backups&quot;: [&quot;backup_dir_name&quot;, ...] }</code></li>
+</ul>
+<hr>
+<h3>POST /api/backup</h3>
+<p>Creates a full manual backup of the server directory.</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: string }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
+<h3>DELETE /api/backups/:backupName</h3>
+<p>Deletes a specific manual backup.</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: string }</code></li>
+<li><code>400 Bad Request</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
+<h2>Log Management</h2>
+<h3>GET /api/logs</h3>
+<p>Retrieves the last 100 lines (or up to 16KB) of the server log.</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;logs&quot;: &quot;string&quot; }</code></li>
+</ul>
+<hr>
+<h3>POST /api/logs/clear</h3>
+<p>Clears the server log file.</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;message&quot;: &quot;Server logs cleared successfully.&quot; }</code></li>
+<li><code>500 Internal Server Error</code>: <code>{ &quot;success&quot;: false, &quot;message&quot;: string }</code></li>
+</ul>
+<hr>
+<h3>GET /api/logs/download</h3>
+<p>Downloads the full <code>server.log</code> file.</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: File download (server.log)</li>
+</ul>
+<hr>
+<h2>System Information</h2>
+<h3>GET /api/system-info</h3>
+<p>Retrieves various system information metrics (CPU load, memory usage, uptime, etc.).</p>
+<p><strong>Response:</strong></p>
+<ul>
+<li><code>200 OK</code>: <code>{ &quot;success&quot;: true, &quot;info&quot;: { ... } }</code></li>
 </ul>
 <hr>
 <h2>Application Configuration</h2>

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -955,6 +955,58 @@ export async function createWorld(worldName) {
     }
 }
 
+/**
+ * Renames a world directory and updates server properties if it was the active world.
+ * @param {string} oldName - The current name of the world.
+ * @param {string} newName - The new name for the world.
+ * @returns {Promise<{success: boolean, message: string, restartRequired?: boolean}>}
+ */
+export async function renameWorld(oldName, newName) {
+    if (!SERVER_DIRECTORY) {
+        return { success: false, message: 'Server directory not configured.' };
+    }
+    if (!isValidWorldName(oldName) || !isValidWorldName(newName)) {
+        return { success: false, message: 'Invalid world name format.' };
+    }
+    if (oldName === newName) {
+        return { success: true, message: 'World name is already the same.' };
+    }
+
+    const worldsPath = path.join(SERVER_DIRECTORY, 'worlds');
+    const oldPath = path.join(worldsPath, oldName);
+    const newPath = path.join(worldsPath, newName);
+
+    if (!fs.existsSync(oldPath)) {
+        return { success: false, message: 'Original world not found.' };
+    }
+    if (fs.existsSync(newPath)) {
+        return { success: false, message: 'A world with the new name already exists.' };
+    }
+
+    try {
+        log('INFO', `Renaming world from '${oldName}' to '${newName}'`);
+        fs.renameSync(oldPath, newPath);
+
+        let restartRequired = false;
+        const properties = await readServerProperties();
+        if (properties['level-name'] === oldName) {
+            log('INFO', `Renamed world was active. Updating level-name to '${newName}'`);
+            properties['level-name'] = newName;
+            await writeServerProperties(properties);
+            restartRequired = true;
+        }
+
+        return {
+            success: true,
+            message: `World renamed from '${oldName}' to '${newName}' successfully.${restartRequired ? ' Server properties updated. Restart required.' : ''}`,
+            restartRequired
+        };
+    } catch (error) {
+        log('ERROR', `Failed to rename world '${oldName}': ${error.message}`);
+        return { success: false, message: `Failed to rename world: ${error.message}` };
+    }
+}
+
 export async function listWorlds() {
     if (!SERVER_DIRECTORY) {
         log('WARNING', 'SERVER_DIRECTORY not set. Cannot list worlds.');

--- a/public/script.js
+++ b/public/script.js
@@ -8,6 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const backupButton = document.getElementById('backupButton');
     const clearLogsButton = document.getElementById('clearLogsButton');
     const downloadLogsButton = document.getElementById('downloadLogsButton');
+    const refreshWorldsButton = document.getElementById('refreshWorldsButton');
+    const refreshBackupsButton = document.getElementById('refreshBackupsButton');
+    const refreshSystemInfoButton = document.getElementById('refreshSystemInfoButton');
     const propertiesForm = document.getElementById('propertiesForm');
     const propertiesContainer = document.getElementById('propertiesContainer');
     const propertiesTabs = document.getElementById('propertiesTabs');
@@ -451,7 +454,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const data = await response.json();
             if (data.success) {
                 // Find the existing .world-list element to update
-                const worldListContainer = document.querySelector('.world-list');
+                const worldListContainer = document.getElementById('worldList');
                 if (worldListContainer) {
                     worldListContainer.innerHTML = ''; // Clear current list
                     if (data.worlds && data.worlds.length > 0) {
@@ -471,6 +474,9 @@ document.addEventListener('DOMContentLoaded', () => {
                                 </button>
                                 <button class="backup-world-button bg-green-600 hover:bg-green-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Backup
+                            </button>
+                            <button class="rename-world-button bg-blue-500 hover:bg-blue-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
+                                Rename
                                 </button>
                                 ${currentLevelName !== world ? `
                                 <button class="delete-world-button bg-red-500 hover:bg-red-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
@@ -482,6 +488,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         });
                         addActivateButtonListeners(); // Re-add listeners after updating DOM
                         addBackupButtonListeners(); // Re-add listeners after updating DOM
+                        addRenameButtonListeners(); // Re-add listeners after updating DOM
                         addDeleteButtonListeners(); // Re-add listeners after updating DOM
                     } else {
                         worldListContainer.innerHTML = '<p class="text-gray-600">No worlds found. Start the server to generate a default world.</p>';
@@ -509,6 +516,13 @@ document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('.backup-world-button').forEach(button => {
             button.removeEventListener('click', handleBackupWorldClick); // Prevent duplicate listeners
             button.addEventListener('click', handleBackupWorldClick);
+        });
+    }
+
+    function addRenameButtonListeners() {
+        document.querySelectorAll('.rename-world-button').forEach(button => {
+            button.removeEventListener('click', handleRenameWorldClick); // Prevent duplicate listeners
+            button.addEventListener('click', handleRenameWorldClick);
         });
     }
 
@@ -665,6 +679,37 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    async function handleRenameWorldClick(event) {
+        const oldWorldName = event.target.dataset.worldName;
+        const newWorldName = prompt(`Enter new name for world '${oldWorldName}':`, oldWorldName);
+
+        if (!newWorldName || newWorldName === oldWorldName) return;
+
+        try {
+            showMessage(`Renaming world '${oldWorldName}' to '${newWorldName}'...`);
+            const response = await fetch('/api/rename-world', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ oldWorldName, newWorldName })
+            });
+            const data = await response.json();
+            if (response.ok && data.success) {
+                showMessage(data.message, 'success');
+                if (data.restartRequired && restartNeededNote) {
+                    restartNeededNote.style.display = 'block';
+                }
+                loadWorlds(); // Refresh world list
+            } else {
+                showMessage(data.message || `Failed to rename world '${oldWorldName}'.`, 'error');
+            }
+        } catch (error) {
+            console.error('Error renaming world:', error);
+            showMessage('An error occurred while renaming the world.', 'error');
+        }
+    }
+
     // --- Auto-Update Configuration Functions ---
     async function loadAutoUpdateConfig() {
         try {
@@ -792,6 +837,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     if (clearLogsButton) clearLogsButton.addEventListener('click', handleClearLogs);
+    if (refreshWorldsButton) refreshWorldsButton.addEventListener('click', loadWorlds);
+    if (refreshBackupsButton) refreshBackupsButton.addEventListener('click', loadBackups);
+    if (refreshSystemInfoButton) refreshSystemInfoButton.addEventListener('click', fetchSystemInfo);
     if (createWorldForm) createWorldForm.addEventListener('submit', handleCreateWorld);
     if (uploadWorldForm) uploadWorldForm.addEventListener('submit', handleUploadWorld);
     if (downloadLogsButton) {
@@ -881,11 +929,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initial load
     fetchServerStatus(); // This will now also set initial button states
     loadServerProperties();
-    //loadWorlds();
+    loadWorlds();
     loadBackups();
     loadAutoUpdateConfig(); // New: Load auto-update config on page load
     addActivateButtonListeners();
     addBackupButtonListeners();
+    addRenameButtonListeners();
     addDeleteButtonListeners();
     fetchLogs();
     fetchSystemInfo();

--- a/test/rename_world.test.js
+++ b/test/rename_world.test.js
@@ -1,0 +1,88 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import * as path from 'path';
+
+// Mock the backend module
+jest.unstable_mockModule('../minecraft_bedrock_installer_nodejs.js', () => ({
+  init: jest.fn(),
+  isProcessRunning: jest.fn(),
+  readServerProperties: jest.fn(),
+  writeServerProperties: jest.fn(),
+  listWorlds: jest.fn(),
+  renameWorld: jest.fn(),
+  readGlobalConfig: jest.fn(),
+  isValidWorldName: jest.fn(),
+  log: jest.fn(),
+  startAutoUpdateScheduler: jest.fn(),
+  getStoredVersion: jest.fn(),
+}));
+
+// Mock the fs module
+jest.unstable_mockModule('fs', () => ({
+    existsSync: jest.fn().mockReturnValue(true),
+    mkdirSync: jest.fn(),
+    createWriteStream: jest.fn(() => ({ write: jest.fn() })),
+    readFileSync: jest.fn(),
+    writeFileSync: jest.fn(),
+    promises: {
+        readFile: jest.fn(),
+        writeFile: jest.fn(),
+        truncate: jest.fn(),
+        stat: jest.fn(),
+        open: jest.fn(),
+    }
+}));
+
+// Dynamically import the app and the mocked backend after setup
+const { default: app } = await import('../app.js');
+const backend = await import('../minecraft_bedrock_installer_nodejs.js');
+
+describe('World Rename API', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    backend.readGlobalConfig.mockResolvedValue({ uiPort: 3000 });
+    backend.isValidWorldName.mockImplementation((name) => /^[a-zA-Z0-9_ -]+$/.test(name));
+  });
+
+  it('should rename a world successfully via API', async () => {
+    backend.renameWorld.mockResolvedValue({ success: true, message: 'World renamed successfully.', restartRequired: false });
+
+    const res = await request(app)
+      .post('/api/rename-world')
+      .send({ oldWorldName: 'OldWorld', newWorldName: 'NewWorld' });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual({ success: true, message: 'World renamed successfully.', restartRequired: false });
+    expect(backend.renameWorld).toHaveBeenCalledWith('OldWorld', 'NewWorld');
+  });
+
+  it('should return 400 if world names are missing', async () => {
+    const res = await request(app)
+      .post('/api/rename-world')
+      .send({ oldWorldName: 'OldWorld' });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.message).toContain('required');
+  });
+
+  it('should return 400 if new world name is invalid', async () => {
+    const res = await request(app)
+      .post('/api/rename-world')
+      .send({ oldWorldName: 'OldWorld', newWorldName: 'Invalid/Name' });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.message).toContain('Invalid world name format');
+  });
+
+  it('should return 400 if backend renameWorld fails', async () => {
+    backend.renameWorld.mockResolvedValue({ success: false, message: 'A world with the new name already exists.' });
+
+    const res = await request(app)
+      .post('/api/rename-world')
+      .send({ oldWorldName: 'OldWorld', newWorldName: 'ExistingWorld' });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.message).toBe('A world with the new name already exists.');
+  });
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -33,7 +33,10 @@
         <% } %>
 
         <div class="section" id="systemInfoSection">
-            <h2>System Information</h2>
+            <div class="section-header">
+                <h2>System Information</h2>
+                <button id="refreshSystemInfoButton" class="bg-gray-500 hover:bg-gray-700" style="width: auto; padding: 5px 10px; font-size: 0.8rem;">Refresh</button>
+            </div>
             <div id="systemInfoContent" class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <p>Loading system information...</p>
             </div>
@@ -84,7 +87,10 @@
         </div>
 
         <div class="section">
-            <h2>Backup Management</h2>
+            <div class="section-header">
+                <h2>Backup Management</h2>
+                <button id="refreshBackupsButton" class="bg-gray-500 hover:bg-gray-700" style="width: auto; padding: 5px 10px; font-size: 0.8rem;">Refresh</button>
+            </div>
             <div id="backupList" class="world-list">
                 <p>Loading backups...</p>
             </div>
@@ -106,7 +112,10 @@
         </div>
 
         <div class="section">
-            <h2>World Management</h2>
+            <div class="section-header">
+                <h2>World Management</h2>
+                <button id="refreshWorldsButton" class="bg-gray-500 hover:bg-gray-700" style="width: auto; padding: 5px 10px; font-size: 0.8rem;">Refresh</button>
+            </div>
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 20px;">
                 <form id="createWorldForm">
                     <div class="form-group">
@@ -123,7 +132,7 @@
                     <button type="submit" id="uploadWorldButton">Upload World</button>
                 </form>
             </div>
-            <div class="world-list">
+            <div id="worldList" class="world-list">
                 <% if (worlds && worlds.length > 0) { %>
                     <% worlds.forEach(world => { %>
                         <div class="world-item <%= properties['level-name'] === world ? 'active' : '' %>" data-world-name="<%= world %>">
@@ -133,6 +142,9 @@
                             </button>
                             <button class="backup-world-button bg-green-600 hover:bg-green-700" data-world-name="<%= world %>">
                                 Backup
+                            </button>
+                            <button class="rename-world-button bg-blue-500 hover:bg-blue-700" data-world-name="<%= world %>">
+                                Rename
                             </button>
                             <% if (properties['level-name'] !== world) { %>
                                 <button class="delete-world-button bg-red-500 hover:bg-red-700" data-world-name="<%= world %>">


### PR DESCRIPTION
This PR introduces several enhancements and fixes to the Bedrock Server Manager:

1.  **World Renaming**: Users can now rename their worlds directly from the web interface. The backend automatically updates `server.properties` if the active world is renamed, ensuring seamless transitions.
2.  **UI Improvements**: 
    - Added "Refresh" buttons to several dashboard sections (System Info, Backups, Worlds) to allow manual updates without a full page reload.
    - Improved DOM selection for the world list by using a unique ID (`worldList`), making the frontend more robust.
    - Fixed a bug where the world list was not being populated on initial page load.
3.  **Documentation**: Comprehensively updated `docs/API.html` to document previously undocumented endpoints (status, players, commands, management) and the new rename endpoint.
4.  **Testing**: Added a new test suite `test/rename_world.test.js` and verified that all 49 existing and new tests pass.

These changes follow SOLID, DRY, and KISS principles, improving both the functionality and maintainability of the application.

---
*PR created automatically by Jules for task [6936222608195417904](https://jules.google.com/task/6936222608195417904) started by @brettfxio*