### PR TITLE
Implement Rename World Feature and Fix UI Bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -342,6 +342,31 @@ app.post('/api/delete-world', validateWorldName, async (req, res) => {
     }
 });
 
+app.post('/api/rename-world', async (req, res, next) => {
+    // Custom validation for oldWorldName and newWorldName
+    const { oldWorldName, newWorldName } = req.body;
+    if (!oldWorldName || !newWorldName) {
+        return res.status(400).json({ error: 'Both oldWorldName and newWorldName are required.' });
+    }
+    if (!backend.isValidWorldName(oldWorldName) || !backend.isValidWorldName(newWorldName)) {
+        return res.status(400).json({ error: 'Invalid worldName format.' });
+    }
+    next();
+}, async (req, res) => {
+    try {
+        const { oldWorldName, newWorldName } = req.body;
+        const result = await backend.renameWorld(oldWorldName, newWorldName);
+        if (result.success) {
+            res.json(result);
+        } else {
+            res.status(400).json(result);
+        }
+    } catch (error) {
+        backend.log('ERROR', `Failed to rename world: ${error.message}`);
+        res.status(500).json({ success: false, message: 'Failed to rename world due to server error.' });
+    }
+});
+
 app.post('/api/activate-world', validateWorldName, async (req, res) => {
     try {
         const { worldName } = req.body;

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -1035,6 +1035,49 @@ export async function deleteWorld(worldName) {
     }
 }
 
+/**
+ * Renames a world directory and updates server.properties if it's the active world.
+ * @param {string} oldName
+ * @param {string} newName
+ * @returns {Promise<{success: boolean, message: string}>}
+ */
+export async function renameWorld(oldName, newName) {
+    if (!SERVER_DIRECTORY) {
+        return { success: false, message: 'Server directory not configured.' };
+    }
+    if (!isValidWorldName(oldName) || !isValidWorldName(newName)) {
+        return { success: false, message: 'Invalid world name format.' };
+    }
+
+    const worldsPath = path.join(SERVER_DIRECTORY, 'worlds');
+    const oldPath = path.join(worldsPath, oldName);
+    const newPath = path.join(worldsPath, newName);
+
+    if (!fs.existsSync(oldPath)) {
+        return { success: false, message: `World '${oldName}' not found.` };
+    }
+    if (fs.existsSync(newPath)) {
+        return { success: false, message: `A world named '${newName}' already exists.` };
+    }
+
+    try {
+        log('INFO', `Renaming world from '${oldName}' to '${newName}'`);
+        await fs.promises.rename(oldPath, newPath);
+
+        const properties = await readServerProperties();
+        if (properties['level-name'] === oldName) {
+            log('INFO', `Updating active world name in server.properties to '${newName}'`);
+            properties['level-name'] = newName;
+            await writeServerProperties(properties);
+        }
+
+        return { success: true, message: `World renamed from '${oldName}' to '${newName}'.` };
+    } catch (error) {
+        log('ERROR', `Failed to rename world: ${error.message}`);
+        return { success: false, message: `Failed to rename world: ${error.message}` };
+    }
+}
+
 export async function activateWorld(worldName) {
     if (!SERVER_DIRECTORY) {
         log('ERROR', 'SERVER_DIRECTORY not set. Cannot activate world.');

--- a/public/script.js
+++ b/public/script.js
@@ -525,8 +525,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const response = await fetch('/api/worlds');
             const data = await response.json();
             if (data.success) {
-                // Find the existing .world-list element to update
-                const worldListContainer = document.querySelector('.world-list');
+                // Find the existing worldList element to update
+                const worldListContainer = document.getElementById('worldList');
                 if (worldListContainer) {
                     worldListContainer.innerHTML = ''; // Clear current list
                     if (data.worlds && data.worlds.length > 0) {
@@ -547,6 +547,9 @@ document.addEventListener('DOMContentLoaded', () => {
                                 <button class="backup-world-button bg-green-600 hover:bg-green-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Backup
                                 </button>
+                                <button class="rename-world-button bg-blue-500 hover:bg-blue-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
+                                    Rename
+                                </button>
                                 ${currentLevelName !== world ? `
                                 <button class="delete-world-button bg-red-500 hover:bg-red-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Delete
@@ -558,6 +561,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         addActivateButtonListeners(); // Re-add listeners after updating DOM
                         addBackupButtonListeners(); // Re-add listeners after updating DOM
                         addDeleteButtonListeners(); // Re-add listeners after updating DOM
+                        addRenameButtonListeners(); // Re-add listeners after updating DOM
                     } else {
                         worldListContainer.innerHTML = '<p class="text-gray-600">No worlds found. Start the server to generate a default world.</p>';
                     }
@@ -592,6 +596,42 @@ document.addEventListener('DOMContentLoaded', () => {
             button.removeEventListener('click', handleDeleteWorldClick); // Prevent duplicate listeners
             button.addEventListener('click', handleDeleteWorldClick);
         });
+    }
+
+    function addRenameButtonListeners() {
+        document.querySelectorAll('.rename-world-button').forEach(button => {
+            button.removeEventListener('click', handleRenameWorldClick); // Prevent duplicate listeners
+            button.addEventListener('click', handleRenameWorldClick);
+        });
+    }
+
+    async function handleRenameWorldClick(event) {
+        const oldWorldName = event.target.dataset.worldName;
+        const newWorldName = prompt(`Enter new name for world '${oldWorldName}':`, oldWorldName);
+
+        if (!newWorldName || newWorldName === oldWorldName) return;
+
+        try {
+            showMessage(`Renaming world '${oldWorldName}' to '${newWorldName}'...`);
+            const response = await fetch('/api/rename-world', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ oldWorldName, newWorldName })
+            });
+            const data = await response.json();
+            if (response.ok && data.success) {
+                showMessage(data.message || `World renamed to '${newWorldName}'.`, 'success');
+                loadWorlds(); // Refresh world list
+                loadServerProperties(); // Refresh properties in case level-name changed
+            } else {
+                showMessage(data.message || data.error || `Failed to rename world.`, 'error');
+            }
+        } catch (error) {
+            console.error('Error renaming world:', error);
+            showMessage('Failed to rename world.', 'error');
+        }
     }
 
     async function handleDeleteWorldClick(event) {
@@ -967,6 +1007,7 @@ document.addEventListener('DOMContentLoaded', () => {
     addActivateButtonListeners();
     addBackupButtonListeners();
     addDeleteButtonListeners();
+    addRenameButtonListeners();
     fetchLogs();
     fetchSystemInfo();
 

--- a/test/rename_world.test.js
+++ b/test/rename_world.test.js
@@ -1,0 +1,88 @@
+import request from 'supertest';
+import * as fs from 'fs';
+import path from 'path';
+import os from 'os';
+import app from '../app.js';
+import * as backend from '../minecraft_bedrock_installer_nodejs.js';
+
+describe('Rename World Feature', () => {
+    let testDir;
+    let serverDir;
+    let worldsDir;
+
+    beforeEach(() => {
+        testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-world-test-'));
+        serverDir = path.join(testDir, 'server');
+        worldsDir = path.join(serverDir, 'worlds');
+        fs.mkdirSync(worldsDir, { recursive: true });
+
+        backend.init({
+            serverDirectory: serverDir,
+            tempDirectory: path.join(testDir, 'temp'),
+            backupDirectory: path.join(testDir, 'backup'),
+            logLevel: 'DEBUG'
+        });
+    });
+
+    afterEach(() => {
+        fs.rmSync(testDir, { recursive: true, force: true });
+    });
+
+    test('renameWorld backend function renames directory and updates server.properties', async () => {
+        const oldName = 'OldWorld';
+        const newName = 'NewWorld';
+        const oldPath = path.join(worldsDir, oldName);
+        const newPath = path.join(worldsDir, newName);
+        const propertiesPath = path.join(serverDir, 'server.properties');
+
+        fs.mkdirSync(oldPath);
+        fs.writeFileSync(propertiesPath, `level-name=${oldName}\n`);
+
+        const result = await backend.renameWorld(oldName, newName);
+
+        expect(result.success).toBe(true);
+        expect(fs.existsSync(oldPath)).toBe(false);
+        expect(fs.existsSync(newPath)).toBe(true);
+
+        const updatedProperties = fs.readFileSync(propertiesPath, 'utf8');
+        expect(updatedProperties).toContain(`level-name=${newName}`);
+    });
+
+    test('POST /api/rename-world renames a world', async () => {
+        const oldName = 'OldWorldAPI';
+        const newName = 'NewWorldAPI';
+        const oldPath = path.join(worldsDir, oldName);
+        const newPath = path.join(worldsDir, newName);
+
+        fs.mkdirSync(oldPath);
+
+        const response = await request(app)
+            .post('/api/rename-world')
+            .send({ oldWorldName: oldName, newWorldName: newName });
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(fs.existsSync(oldPath)).toBe(false);
+        expect(fs.existsSync(newPath)).toBe(true);
+    });
+
+    test('POST /api/rename-world returns 400 for invalid names', async () => {
+        const response = await request(app)
+            .post('/api/rename-world')
+            .send({ oldWorldName: 'ValidName', newWorldName: 'Invalid/Name' });
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBeDefined();
+    });
+
+    test('renameWorld returns error if target name already exists', async () => {
+        const oldName = 'OldWorldExist';
+        const newName = 'ExistingWorld';
+        fs.mkdirSync(path.join(worldsDir, oldName));
+        fs.mkdirSync(path.join(worldsDir, newName));
+
+        const result = await backend.renameWorld(oldName, newName);
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('already exists');
+    });
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -123,7 +123,7 @@
                     <button type="submit" id="uploadWorldButton">Upload World</button>
                 </form>
             </div>
-            <div class="world-list">
+            <div class="world-list" id="worldList">
                 <% if (worlds && worlds.length > 0) { %>
                     <% worlds.forEach(world => { %>
                         <div class="world-item <%= properties['level-name'] === world ? 'active' : '' %>" data-world-name="<%= world %>">
@@ -133,6 +133,9 @@
                             </button>
                             <button class="backup-world-button bg-green-600 hover:bg-green-700" data-world-name="<%= world %>">
                                 Backup
+                            </button>
+                            <button class="rename-world-button bg-blue-500 hover:bg-blue-700" data-world-name="<%= world %>">
+                                Rename
                             </button>
                             <% if (properties['level-name'] !== world) { %>
                                 <button class="delete-world-button bg-red-500 hover:bg-red-700" data-world-name="<%= world %>">


### PR DESCRIPTION
This PR introduces the ability for users to rename Minecraft worlds directly from the management interface. 

### Changes:
- **Backend**: New `renameWorld` function in `minecraft_bedrock_installer_nodejs.js`. It renames the world's directory and, if the world is currently active, updates the `level-name` property in `server.properties` to ensure the server remains correctly configured.
- **API**: New `POST /api/rename-world` endpoint with robust validation for world names.
- **Frontend**: Added a "Rename" button to the world list in the web UI. Clicking it prompts for a new name and handles the API interaction.
- **Bug Fix**: Fixed a selector issue in `public/script.js` where the world management logic was sometimes incorrectly targeting the backup list container.
- **Testing**: Added `test/rename_world.test.js` covering backend logic, API responses, and edge cases. All 53 tests in the suite now pass.

### Visual Verification:
Frontend changes were verified using Playwright. A "Rename" button correctly appears next to each world, prompts for input, and successfully updates the UI upon completion.

---
*PR created automatically by Jules for task [11051447927217595907](https://jules.google.com/task/11051447927217595907) started by @brettfxio*