### PR TITLE
Improve Pack Management and Server Properties UI

### DIFF
--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -1513,6 +1513,31 @@ export async function listPacks(worldName) {
     const worldPath = path.join(SERVER_DIRECTORY, 'worlds', worldName);
     if (!fs.existsSync(worldPath)) return { success: false, message: 'World not found.' };
 
+    const resolvePackNames = async (packs, packTypeDir) => {
+        const packTypePath = path.join(SERVER_DIRECTORY, packTypeDir);
+        if (!fs.existsSync(packTypePath)) return packs;
+
+        const nameMap = new Map();
+        try {
+            const entries = await fs.promises.readdir(packTypePath, { withFileTypes: true });
+            for (const entry of entries) {
+                if (entry.isDirectory()) {
+                    const manifest = await readManifest(path.join(packTypePath, entry.name));
+                    if (manifest && manifest.header && manifest.header.uuid) {
+                        nameMap.set(manifest.header.uuid, manifest.header.name);
+                    }
+                }
+            }
+        } catch (e) {
+            log('ERROR', `Error scanning ${packTypeDir} for names: ${e.message}`);
+        }
+
+        return packs.map(pack => ({
+            ...pack,
+            name: nameMap.get(pack.pack_id)
+        }));
+    };
+
     const readPackJson = async (fileName) => {
         const filePath = path.join(worldPath, fileName);
         if (fs.existsSync(filePath)) {
@@ -1526,8 +1551,11 @@ export async function listPacks(worldName) {
         return [];
     };
 
-    const behaviorPacks = await readPackJson('world_behavior_packs.json');
-    const resourcePacks = await readPackJson('world_resource_packs.json');
+    let behaviorPacks = await readPackJson('world_behavior_packs.json');
+    let resourcePacks = await readPackJson('world_resource_packs.json');
+
+    behaviorPacks = await resolvePackNames(behaviorPacks, 'behavior_packs');
+    resourcePacks = await resolvePackNames(resourcePacks, 'resource_packs');
 
     return { success: true, behaviorPacks, resourcePacks };
 }

--- a/public/script.js
+++ b/public/script.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const uploadWorldButton = document.getElementById('uploadWorldButton');
 
     const restartNeededNote = document.getElementById('restartNeededNote');
+    const propertiesSearch = document.getElementById('propertiesSearch');
 
     // Pack Management specific elements
     const uploadPackForm = document.getElementById('uploadPackForm');
@@ -102,10 +103,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 const createPackItem = (pack, type) => {
                     const item = document.createElement('div');
                     item.className = 'world-item';
+                    const displayName = pack.name || pack.pack_id;
                     item.innerHTML = `
                         <div style="flex-grow: 1;">
-                            <strong>${type === 'behavior' ? 'Behavior' : 'Resource'}:</strong> ${pack.pack_id}
-                            <div style="font-size: 0.8rem; color: #aaa;">Version: ${pack.version.join('.')}</div>
+                            <strong>${type === 'behavior' ? 'Behavior' : 'Resource'}:</strong> ${displayName}
+                            <div style="font-size: 0.8rem; color: #aaa;">${pack.name ? 'ID: ' + pack.pack_id + ' | ' : ''}Version: ${pack.version.join('.')}</div>
                         </div>
                         <button class="delete-pack-button bg-red-500 hover:bg-red-700 text-white text-sm py-1 px-3 rounded transition duration-300"
                                 data-world-name="${worldName}" data-pack-type="${type}" data-pack-id="${pack.pack_id}">
@@ -303,30 +305,38 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function renderPropertiesUI() {
+    function renderPropertiesUI(filter = '') {
         propertiesTabs.innerHTML = '';
         propertiesContainer.innerHTML = '';
+        const searchTerm = filter.toLowerCase();
 
         propertyCategories.forEach((category, index) => {
             const tabButton = document.createElement('button');
             tabButton.type = 'button';
-            tabButton.className = `tab-button ${index === 0 ? 'active' : ''}`;
+            tabButton.className = 'tab-button';
             tabButton.textContent = category.label;
             tabButton.onclick = () => switchTab(category.id);
             propertiesTabs.appendChild(tabButton);
 
             const categorySection = document.createElement('div');
             categorySection.id = `category-${category.id}`;
-            categorySection.className = `tab-content ${index === 0 ? 'active' : ''}`;
+            categorySection.className = 'tab-content';
 
             const grid = document.createElement('div');
             grid.className = 'form-grid';
 
+            let visibleCount = 0;
+
             // Filter properties for this category
             Object.entries(propertiesMetadata).forEach(([key, meta]) => {
                 if (meta.category === category.id) {
-                    const value = currentServerProperties[key] || '';
-                    grid.appendChild(createPropertyElement(key, meta, value));
+                    const labelMatch = (meta.label || '').toLowerCase().includes(searchTerm);
+                    const keyMatch = key.toLowerCase().includes(searchTerm);
+                    if (!searchTerm || labelMatch || keyMatch) {
+                        const value = currentServerProperties[key] || '';
+                        grid.appendChild(createPropertyElement(key, meta, value));
+                        visibleCount++;
+                    }
                 }
             });
 
@@ -334,14 +344,35 @@ document.addEventListener('DOMContentLoaded', () => {
             if (category.id === 'advanced') {
                 Object.entries(currentServerProperties).forEach(([key, value]) => {
                     if (!propertiesMetadata[key]) {
-                        grid.appendChild(createPropertyElement(key, { label: key, type: 'string', description: 'Advanced setting' }, value));
+                        const keyMatch = key.toLowerCase().includes(searchTerm);
+                        if (!searchTerm || keyMatch) {
+                            grid.appendChild(createPropertyElement(key, { label: key, type: 'string', description: 'Advanced setting' }, value));
+                            visibleCount++;
+                        }
                     }
                 });
+            }
+
+            const hasMatch = visibleCount > 0;
+            if (!hasMatch && searchTerm) {
+                tabButton.style.display = 'none';
+                categorySection.style.display = 'none';
             }
 
             categorySection.appendChild(grid);
             propertiesContainer.appendChild(categorySection);
         });
+
+        // Handle initial active state
+        const visibleTabs = Array.from(propertiesTabs.querySelectorAll('.tab-button:not([style*="display: none"])'));
+        if (visibleTabs.length > 0) {
+            const firstTab = visibleTabs[0];
+            const categoryId = propertyCategories.find(c => c.label === firstTab.textContent).id;
+            firstTab.classList.add('active');
+            const content = document.getElementById(`category-${categoryId}`);
+            content.classList.add('active');
+            content.style.display = '';
+        }
     }
 
     function createPropertyElement(key, meta, value) {
@@ -876,6 +907,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (propertiesForm) propertiesForm.addEventListener('submit', saveServerProperties);
     if (autoUpdateConfigForm) autoUpdateConfigForm.addEventListener('submit', saveAutoUpdateConfig);
+    if (propertiesSearch) {
+        propertiesSearch.addEventListener('input', (e) => {
+            renderPropertiesUI(e.target.value);
+        });
+    }
     if (uploadPackForm) {
         uploadPackForm.addEventListener('submit', async (e) => {
             await handleUploadPack(e);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -192,6 +192,9 @@
 
         <div class="section">
             <h2>Server Properties</h2>
+            <div class="form-group" style="margin-bottom: 15px;">
+                <input type="text" id="propertiesSearch" placeholder="Search properties by name or key..." style="width: 100%; max-width: 400px;">
+            </div>
             <div id="restartNeededNote" class="info-box" style="display: none; background-color: #fff3cd; border: 1px solid #ffeeba; color: #856404; padding: 10px; margin-bottom: 15px; border-radius: 4px;">
                 <strong>Notice:</strong> Server properties have been updated. A restart is required for these changes to take effect.
             </div>


### PR DESCRIPTION
This PR enhances the Bedrock Server Manager by resolving human-readable names for Minecraft packs and adding a real-time search filter for server properties.

Key changes:
1.  **Pack Name Resolution**: The backend `listPacks` function now scans the `behavior_packs` and `resource_packs` directories to resolve human-readable names from `manifest.json` files. This is implemented efficiently using an in-memory lookup map.
2.  **Server Properties Search**: A new search bar allows users to filter server properties by label or key across all categories. The UI dynamically hides non-matching properties and their corresponding tabs.
3.  **UI/UX Improvements**: The pack management section now displays the resolved name (falling back to UUID) for better clarity. The property search logic was refined to maintain correct styling and focus.

Visual verification was performed using Playwright, and all existing tests pass.

---
*PR created automatically by Jules for task [6485690874315539476](https://jules.google.com/task/6485690874315539476) started by @brettfxio*