### PR TITLE
Add Rename World Feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -327,6 +327,27 @@ app.post('/api/create-world', validateWorldName, async (req, res) => {
     }
 });
 
+app.post('/api/rename-world', async (req, res) => {
+    try {
+        const { oldWorldName, newWorldName } = req.body;
+        if (!oldWorldName || !newWorldName) {
+            return res.status(400).json({ success: false, message: 'Both old and new world names are required.' });
+        }
+        if (!backend.isValidWorldName(oldWorldName) || !backend.isValidWorldName(newWorldName)) {
+            return res.status(400).json({ success: false, message: 'Invalid world name format.' });
+        }
+        const result = await backend.renameWorld(oldWorldName, newWorldName);
+        if (result.success) {
+            res.json(result);
+        } else {
+            res.status(400).json(result);
+        }
+    } catch (error) {
+        backend.log('ERROR', `Failed to rename world: ${error.message}`);
+        res.status(500).json({ success: false, message: 'Failed to rename world due to server error.' });
+    }
+});
+
 app.post('/api/delete-world', validateWorldName, async (req, res) => {
     try {
         const { worldName } = req.body;

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -955,6 +955,54 @@ export async function writeServerProperties(propertiesToWrite) {
     log('INFO', `Wrote server.properties to ${configPath} (preserved comments and order)`);
 }
 
+/**
+ * Renames an existing world.
+ * @param {string} oldWorldName - The current name of the world.
+ * @param {string} newWorldName - The new name for the world.
+ * @returns {Promise<{success: boolean, message: string}>}
+ */
+export async function renameWorld(oldWorldName, newWorldName) {
+    if (!SERVER_DIRECTORY) {
+        return { success: false, message: 'Server directory not configured.' };
+    }
+    if (!isValidWorldName(oldWorldName) || !isValidWorldName(newWorldName)) {
+        log('ERROR', `Invalid world name format for rename: ${oldWorldName} -> ${newWorldName}`);
+        return { success: false, message: 'Invalid world name format.' };
+    }
+
+    const worldsPath = path.join(SERVER_DIRECTORY, 'worlds');
+    const oldWorldPath = path.join(worldsPath, oldWorldName);
+    const newWorldPath = path.join(worldsPath, newWorldName);
+
+    if (!fs.existsSync(oldWorldPath)) {
+        log('WARNING', `World directory '${oldWorldName}' not found at ${oldWorldPath}.`);
+        return { success: false, message: 'Source world not found.' };
+    }
+
+    if (fs.existsSync(newWorldPath)) {
+        log('WARNING', `Target world directory '${newWorldName}' already exists at ${newWorldPath}.`);
+        return { success: false, message: 'Target world name already exists.' };
+    }
+
+    try {
+        fs.renameSync(oldWorldPath, newWorldPath);
+        log('INFO', `Renamed world directory from '${oldWorldName}' to '${newWorldName}'`);
+
+        // Update server.properties if the active world was renamed
+        const properties = await readServerProperties();
+        if (properties['level-name'] === oldWorldName) {
+            log('INFO', `Active world renamed. Updating level-name in server.properties.`);
+            properties['level-name'] = newWorldName;
+            await writeServerProperties(properties);
+        }
+
+        return { success: true, message: `World '${oldWorldName}' renamed to '${newWorldName}' successfully.` };
+    } catch (error) {
+        log('ERROR', `Failed to rename world '${oldWorldName}' to '${newWorldName}': ${error.message}`);
+        return { success: false, message: `Failed to rename world: ${error.message}` };
+    }
+}
+
 export async function createWorld(worldName) {
     if (!SERVER_DIRECTORY) {
         log('ERROR', 'SERVER_DIRECTORY not set. Cannot create world.');

--- a/public/script.js
+++ b/public/script.js
@@ -525,8 +525,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const response = await fetch('/api/worlds');
             const data = await response.json();
             if (data.success) {
-                // Find the existing .world-list element to update
-                const worldListContainer = document.querySelector('.world-list');
+                // Find the existing world-list element to update
+                const worldListContainer = document.getElementById('worldList');
                 if (worldListContainer) {
                     worldListContainer.innerHTML = ''; // Clear current list
                     if (data.worlds && data.worlds.length > 0) {
@@ -544,6 +544,9 @@ document.addEventListener('DOMContentLoaded', () => {
                                 <button class="activate-world-button bg-blue-500 hover:bg-blue-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Activate
                                 </button>
+                                <button class="rename-world-button bg-gray-500 hover:bg-gray-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
+                                    Rename
+                                </button>
                                 <button class="backup-world-button bg-green-600 hover:bg-green-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Backup
                                 </button>
@@ -556,6 +559,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             worldListContainer.appendChild(worldItem);
                         });
                         addActivateButtonListeners(); // Re-add listeners after updating DOM
+                        addRenameButtonListeners(); // Re-add listeners after updating DOM
                         addBackupButtonListeners(); // Re-add listeners after updating DOM
                         addDeleteButtonListeners(); // Re-add listeners after updating DOM
                     } else {
@@ -577,6 +581,13 @@ document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('.activate-world-button').forEach(button => {
             button.removeEventListener('click', handleActivateWorldClick); // Prevent duplicate listeners
             button.addEventListener('click', handleActivateWorldClick);
+        });
+    }
+
+    function addRenameButtonListeners() {
+        document.querySelectorAll('.rename-world-button').forEach(button => {
+            button.removeEventListener('click', handleRenameWorldClick); // Prevent duplicate listeners
+            button.addEventListener('click', handleRenameWorldClick);
         });
     }
 
@@ -737,6 +748,34 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (error) {
             console.error('Error activating world:', error);
             showMessage('Failed to activate world.', 'error');
+        }
+    }
+
+    async function handleRenameWorldClick(event) {
+        const oldWorldName = event.target.dataset.worldName;
+        const newWorldName = prompt(`Enter new name for world '${oldWorldName}':`, oldWorldName);
+
+        if (!newWorldName || newWorldName === oldWorldName) return;
+
+        try {
+            showMessage(`Renaming world '${oldWorldName}' to '${newWorldName}'...`);
+            const response = await fetch('/api/rename-world', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ oldWorldName, newWorldName })
+            });
+            const data = await response.json();
+            if (response.ok && data.success) {
+                showMessage(data.message || `World renamed successfully.`, 'success');
+                loadWorlds(); // Refresh world list
+            } else {
+                showMessage(data.message || `Failed to rename world.`, 'error');
+            }
+        } catch (error) {
+            console.error('Error renaming world:', error);
+            showMessage('Failed to rename world.', 'error');
         }
     }
 
@@ -965,6 +1004,7 @@ document.addEventListener('DOMContentLoaded', () => {
     loadAutoUpdateConfig(); // New: Load auto-update config on page load
     loadActivePacks();
     addActivateButtonListeners();
+    addRenameButtonListeners();
     addBackupButtonListeners();
     addDeleteButtonListeners();
     fetchLogs();

--- a/test/new_features.test.js
+++ b/test/new_features.test.js
@@ -17,6 +17,7 @@ jest.unstable_mockModule('../minecraft_bedrock_installer_nodejs.js', () => ({
     activateWorld: jest.fn(),
     readGlobalConfig: jest.fn(),
     writeGlobalConfig: jest.fn(),
+    renameWorld: jest.fn(),
     init: jest.fn(),
     startAutoUpdateScheduler: jest.fn(),
     getStoredVersion: jest.fn(),
@@ -70,6 +71,42 @@ describe('New Features API', () => {
             expect(response.status).toBe(400);
             expect(response.body.success).toBe(false);
             expect(response.body.message).toBe('World already exists.');
+        });
+    });
+
+    describe('POST /api/rename-world', () => {
+        it('should rename a world successfully', async () => {
+            backend.renameWorld.mockResolvedValue({ success: true, message: 'World renamed successfully.' });
+
+            const response = await request(app)
+                .post('/api/rename-world')
+                .send({ oldWorldName: 'OldWorld', newWorldName: 'NewWorld' });
+
+            expect(response.status).toBe(200);
+            expect(response.body.success).toBe(true);
+            expect(backend.renameWorld).toHaveBeenCalledWith('OldWorld', 'NewWorld');
+        });
+
+        it('should return 400 for invalid new world name', async () => {
+            const response = await request(app)
+                .post('/api/rename-world')
+                .send({ oldWorldName: 'OldWorld', newWorldName: 'invalid/name' });
+
+            expect(response.status).toBe(400);
+            expect(response.body.success).toBe(false);
+            expect(response.body.message).toBe('Invalid world name format.');
+        });
+
+        it('should return 400 if rename fails in backend', async () => {
+            backend.renameWorld.mockResolvedValue({ success: false, message: 'Target world name already exists.' });
+
+            const response = await request(app)
+                .post('/api/rename-world')
+                .send({ oldWorldName: 'OldWorld', newWorldName: 'ExistingWorld' });
+
+            expect(response.status).toBe(400);
+            expect(response.body.success).toBe(false);
+            expect(response.body.message).toBe('Target world name already exists.');
         });
     });
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -123,13 +123,16 @@
                     <button type="submit" id="uploadWorldButton">Upload World</button>
                 </form>
             </div>
-            <div class="world-list">
+            <div class="world-list" id="worldList">
                 <% if (worlds && worlds.length > 0) { %>
                     <% worlds.forEach(world => { %>
                         <div class="world-item <%= properties['level-name'] === world ? 'active' : '' %>" data-world-name="<%= world %>">
                             <span><%= world %></span>
                             <button class="activate-world-button" data-world-name="<%= world %>">
                                 Activate
+                            </button>
+                            <button class="rename-world-button bg-gray-500 hover:bg-gray-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="<%= world %>">
+                                Rename
                             </button>
                             <button class="backup-world-button bg-green-600 hover:bg-green-700" data-world-name="<%= world %>">
                                 Backup


### PR DESCRIPTION
Implemented a new feature to rename worlds. This includes backend logic to rename the world directory and update `server.properties` if the active world is renamed, a new API endpoint, and UI enhancements to trigger the rename process from the browser. Also fixed a bug where the world list container was not reliably found during dynamic updates.

---
*PR created automatically by Jules for task [7613001605844652277](https://jules.google.com/task/7613001605844652277) started by @brettfxio*