### PR TITLE
Enhance UI with Export, Search, and Human-Readable Pack Names

### DIFF
--- a/app.js
+++ b/app.js
@@ -271,6 +271,29 @@ app.delete('/api/backups/:backupName', async (req, res) => {
     }
 });
 
+app.get('/api/backups/:backupName/download', async (req, res) => {
+    try {
+        const { backupName } = req.params;
+        const result = await backend.exportBackup(backupName);
+        if (result.success) {
+            res.download(result.zipPath, `${backupName}.zip`, (err) => {
+                if (err) {
+                    backend.log('ERROR', `Error downloading backup ZIP: ${err.message}`);
+                }
+                // Cleanup temp file after download
+                fs.promises.unlink(result.zipPath).catch(cleanupErr => {
+                    backend.log('WARNING', `Failed to delete temporary backup ZIP ${result.zipPath}: ${cleanupErr.message}`);
+                });
+            });
+        } else {
+            res.status(400).json(result);
+        }
+    } catch (error) {
+        backend.log('ERROR', `Failed to export backup: ${error.message}`);
+        res.status(500).json({ success: false, message: 'Failed to export backup due to server error.' });
+    }
+});
+
 app.post('/api/backups/:backupName/restore', async (req, res) => {
     try {
         const { backupName } = req.params;
@@ -409,6 +432,29 @@ app.post('/api/backup-world', validateWorldName, async (req, res) => {
     } catch (error) {
         backend.log('ERROR', `Failed to backup world: ${error.message}`);
         res.status(500).json({ success: false, message: 'Failed to create world backup due to server error.' });
+    }
+});
+
+app.get('/api/worlds/:worldName/export', async (req, res) => {
+    try {
+        const { worldName } = req.params;
+        const result = await backend.exportWorld(worldName);
+        if (result.success) {
+            res.download(result.zipPath, `${worldName}.mcworld`, (err) => {
+                if (err) {
+                    backend.log('ERROR', `Error downloading world export: ${err.message}`);
+                }
+                // Cleanup temp file after download
+                fs.promises.unlink(result.zipPath).catch(cleanupErr => {
+                    backend.log('WARNING', `Failed to delete temporary world export ${result.zipPath}: ${cleanupErr.message}`);
+                });
+            });
+        } else {
+            res.status(400).json(result);
+        }
+    } catch (error) {
+        backend.log('ERROR', `Failed to export world: ${error.message}`);
+        res.status(500).json({ success: false, message: 'Failed to export world due to server error.' });
     }
 });
 

--- a/minecraft_bedrock_installer_nodejs.js
+++ b/minecraft_bedrock_installer_nodejs.js
@@ -440,6 +440,51 @@ export async function listBackups() {
  * @param {string} backupName - The name of the backup to delete.
  * @returns {Promise<{success: boolean, message: string}>}
  */
+/**
+ * Zips a backup directory for export.
+ * @param {string} backupName - The name of the backup to export.
+ * @returns {Promise<{success: boolean, zipPath?: string, message?: string}>}
+ */
+/**
+ * Zips a backup directory for export.
+ * @param {string} backupName - The name of the backup to export.
+ * @returns {Promise<{success: boolean, zipPath?: string, message?: string}>}
+ */
+export async function exportBackup(backupName) {
+    if (!BACKUP_DIRECTORY) {
+        return { success: false, message: 'Backup directory not configured.' };
+    }
+    if (!backupName || typeof backupName !== 'string' || backupName.includes('..') || backupName.includes('/') || backupName.includes('\\')) {
+        log('ERROR', `Invalid backup name for export: ${backupName}`);
+        return { success: false, message: 'Invalid backup name.' };
+    }
+
+    const backupPath = path.join(BACKUP_DIRECTORY, backupName);
+    if (!fs.existsSync(backupPath)) {
+        log('WARNING', `Backup not found for export: ${backupPath}`);
+        return { success: false, message: 'Backup not found.' };
+    }
+
+    try {
+        const zip = new AdmZip();
+        zip.addLocalFolder(backupPath);
+        const uniqueId = Date.now() + '-' + Math.floor(Math.random() * 1000);
+        const zipFilename = `backup-${backupName}-${uniqueId}.zip`;
+        const zipPath = path.join(TEMP_DIRECTORY, zipFilename);
+
+        if (!fs.existsSync(TEMP_DIRECTORY)) {
+            fs.mkdirSync(TEMP_DIRECTORY, { recursive: true });
+        }
+
+        zip.writeZip(zipPath);
+        log('INFO', `Backup '${backupName}' zipped to ${zipPath}`);
+        return { success: true, zipPath };
+    } catch (error) {
+        log('ERROR', `Failed to zip backup '${backupName}': ${error.message}`);
+        return { success: false, message: `Failed to zip backup: ${error.message}` };
+    }
+}
+
 export async function deleteBackup(backupName) {
     if (!BACKUP_DIRECTORY) {
         return { success: false, message: 'Backup directory not configured.' };
@@ -1118,6 +1163,51 @@ export async function renameWorld(oldWorldName, newWorldName) {
     }
 }
 
+/**
+ * Zips a world directory for export as .mcworld.
+ * @param {string} worldName - The name of the world to export.
+ * @returns {Promise<{success: boolean, zipPath?: string, message?: string}>}
+ */
+/**
+ * Zips a world directory for export as .mcworld.
+ * @param {string} worldName - The name of the world to export.
+ * @returns {Promise<{success: boolean, zipPath?: string, message?: string}>}
+ */
+export async function exportWorld(worldName) {
+    if (!SERVER_DIRECTORY) {
+        return { success: false, message: 'Server directory not configured.' };
+    }
+    if (!isValidWorldName(worldName)) {
+        log('ERROR', `Invalid world name for export: ${worldName}`);
+        return { success: false, message: 'Invalid world name.' };
+    }
+
+    const worldPath = path.join(SERVER_DIRECTORY, 'worlds', worldName);
+    if (!fs.existsSync(worldPath)) {
+        log('WARNING', `World not found for export: ${worldPath}`);
+        return { success: false, message: 'World not found.' };
+    }
+
+    try {
+        const zip = new AdmZip();
+        zip.addLocalFolder(worldPath);
+        const uniqueId = Date.now() + '-' + Math.floor(Math.random() * 1000);
+        const zipFilename = `world-${worldName}-${uniqueId}.mcworld`;
+        const zipPath = path.join(TEMP_DIRECTORY, zipFilename);
+
+        if (!fs.existsSync(TEMP_DIRECTORY)) {
+            fs.mkdirSync(TEMP_DIRECTORY, { recursive: true });
+        }
+
+        zip.writeZip(zipPath);
+        log('INFO', `World '${worldName}' zipped to ${zipPath}`);
+        return { success: true, zipPath };
+    } catch (error) {
+        log('ERROR', `Failed to zip world '${worldName}': ${error.message}`);
+        return { success: false, message: `Failed to zip world: ${error.message}` };
+    }
+}
+
 export async function createWorld(worldName) {
     if (!SERVER_DIRECTORY) {
         log('ERROR', 'SERVER_DIRECTORY not set. Cannot create world.');
@@ -1691,6 +1781,43 @@ export async function listPacks(worldName) {
 
     const behaviorPacks = await readPackJson('world_behavior_packs.json');
     const resourcePacks = await readPackJson('world_resource_packs.json');
+
+    // Efficiently resolve human-readable names for the packs
+    const buildPackNameMap = async () => {
+        const map = new Map();
+        const packDirs = [
+            'behavior_packs', 'development_behavior_packs',
+            'resource_packs', 'development_resource_packs'
+        ];
+
+        for (const dirName of packDirs) {
+            const baseDirPath = path.join(SERVER_DIRECTORY, dirName);
+            if (!fs.existsSync(baseDirPath)) continue;
+
+            try {
+                const entries = await fs.promises.readdir(baseDirPath, { withFileTypes: true });
+                for (const entry of entries) {
+                    if (entry.isDirectory()) {
+                        const packPath = path.join(baseDirPath, entry.name);
+                        const manifest = await readManifest(packPath);
+                        if (manifest && manifest.header && manifest.header.uuid) {
+                            map.set(manifest.header.uuid, manifest.header.name);
+                        }
+                    }
+                }
+            } catch (e) {
+                log('DEBUG', `Failed to build pack name map for ${dirName}: ${e.message}`);
+            }
+        }
+        return map;
+    };
+
+    const packNameMap = await buildPackNameMap();
+    [...behaviorPacks, ...resourcePacks].forEach(pack => {
+        if (packNameMap.has(pack.pack_id)) {
+            pack.name = packNameMap.get(pack.pack_id);
+        }
+    });
 
     return { success: true, behaviorPacks, resourcePacks };
 }

--- a/public/script.js
+++ b/public/script.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const propertiesForm = document.getElementById('propertiesForm');
     const propertiesContainer = document.getElementById('propertiesContainer');
     const propertiesTabs = document.getElementById('propertiesTabs');
+    const propertySearchInput = document.getElementById('propertySearch');
     const consoleOutput = document.getElementById('consoleOutput'); // Get the console textarea
     const systemInfoContent = document.getElementById('systemInfoContent');
     const backupListContainer = document.getElementById('backupList');
@@ -104,8 +105,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     item.className = 'world-item';
                     item.innerHTML = `
                         <div style="flex-grow: 1;">
-                            <strong>${type === 'behavior' ? 'Behavior' : 'Resource'}:</strong> ${pack.pack_id}
-                            <div style="font-size: 0.8rem; color: #aaa;">Version: ${pack.version.join('.')}</div>
+                            <strong>${type === 'behavior' ? 'Behavior' : 'Resource'}:</strong> ${pack.name || pack.pack_id}
+                            <div style="font-size: 0.8rem; color: #aaa;">${pack.name ? 'ID: ' + pack.pack_id + ' | ' : ''}Version: ${pack.version.join('.')}</div>
                         </div>
                         <button class="delete-pack-button bg-red-500 hover:bg-red-700 text-white text-sm py-1 px-3 rounded transition duration-300"
                                 data-world-name="${worldName}" data-pack-type="${type}" data-pack-id="${pack.pack_id}">
@@ -493,6 +494,9 @@ document.addEventListener('DOMContentLoaded', () => {
                         backupItem.innerHTML = `
                             <span>${backup}</span>
                             <div class="button-group" style="margin-top: 0;">
+                                <button class="download-backup-button bg-green-600 hover:bg-green-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-backup-name="${backup}">
+                                    Download
+                                </button>
                                 <button class="restore-backup-button bg-blue-500 hover:bg-blue-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-backup-name="${backup}">
                                     Restore
                                 </button>
@@ -517,12 +521,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function addBackupActionListeners() {
+        document.querySelectorAll('.download-backup-button').forEach(button => {
+            button.addEventListener('click', handleDownloadBackupClick);
+        });
         document.querySelectorAll('.delete-backup-button').forEach(button => {
             button.addEventListener('click', handleDeleteBackupClick);
         });
         document.querySelectorAll('.restore-backup-button').forEach(button => {
             button.addEventListener('click', handleRestoreBackupClick);
         });
+    }
+
+    async function handleDownloadBackupClick(event) {
+        const backupName = event.target.dataset.backupName;
+        window.location.href = `/api/backups/${backupName}/download`;
     }
 
     async function handleRestoreBackupClick(event) {
@@ -603,6 +615,9 @@ document.addEventListener('DOMContentLoaded', () => {
                                 <button class="activate-world-button bg-blue-500 hover:bg-blue-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Activate
                                 </button>
+                                <button class="export-world-button bg-purple-600 hover:bg-purple-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
+                                    Export
+                                </button>
                                 <button class="rename-world-button bg-gray-500 hover:bg-gray-700 text-white text-sm py-1 px-3 rounded transition duration-300" data-world-name="${world}">
                                     Rename
                                 </button>
@@ -618,6 +633,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             worldListContainer.appendChild(worldItem);
                         });
                         addActivateButtonListeners(); // Re-add listeners after updating DOM
+                        addExportButtonListeners(); // Re-add listeners after updating DOM
                         addRenameButtonListeners(); // Re-add listeners after updating DOM
                         addBackupButtonListeners(); // Re-add listeners after updating DOM
                         addDeleteButtonListeners(); // Re-add listeners after updating DOM
@@ -643,6 +659,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function addExportButtonListeners() {
+        document.querySelectorAll('.export-world-button').forEach(button => {
+            button.removeEventListener('click', handleExportWorldClick); // Prevent duplicate listeners
+            button.addEventListener('click', handleExportWorldClick);
+        });
+    }
+
     function addRenameButtonListeners() {
         document.querySelectorAll('.rename-world-button').forEach(button => {
             button.removeEventListener('click', handleRenameWorldClick); // Prevent duplicate listeners
@@ -662,6 +685,11 @@ document.addEventListener('DOMContentLoaded', () => {
             button.removeEventListener('click', handleDeleteWorldClick); // Prevent duplicate listeners
             button.addEventListener('click', handleDeleteWorldClick);
         });
+    }
+
+    async function handleExportWorldClick(event) {
+        const worldName = event.target.dataset.worldName;
+        window.location.href = `/api/worlds/${worldName}/export`;
     }
 
     async function handleDeleteWorldClick(event) {
@@ -973,6 +1001,42 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
     if (propertiesForm) propertiesForm.addEventListener('submit', saveServerProperties);
+    if (propertySearchInput) {
+        propertySearchInput.addEventListener('input', () => {
+            const query = propertySearchInput.value.toLowerCase();
+            const propertyGroups = propertiesContainer.querySelectorAll('.form-group');
+
+            propertyGroups.forEach(group => {
+                const labelEl = group.querySelector('label');
+                const label = labelEl ? labelEl.textContent.toLowerCase() : '';
+                if (label.includes(query)) {
+                    group.style.display = 'block';
+                } else {
+                    group.style.display = 'none';
+                }
+            });
+
+            // If searching, show all categories and hide tabs
+            if (query) {
+                document.querySelectorAll('.tab-content').forEach(content => {
+                    content.style.display = 'block';
+                    content.classList.add('active');
+                });
+                propertiesTabs.style.display = 'none';
+            } else {
+                // If query is cleared, restore tab view
+                propertiesTabs.style.display = 'flex';
+                const activeTabButton = propertiesTabs.querySelector('.tab-button.active');
+                if (activeTabButton) {
+                    const categoryLabel = activeTabButton.textContent;
+                    const category = propertyCategories.find(c => c.label === categoryLabel);
+                    if (category) {
+                        switchTab(category.id);
+                    }
+                }
+            }
+        });
+    }
     if (autoUpdateConfigForm) autoUpdateConfigForm.addEventListener('submit', saveAutoUpdateConfig);
     if (uploadPackForm) {
         uploadPackForm.addEventListener('submit', async (e) => {
@@ -1063,6 +1127,7 @@ document.addEventListener('DOMContentLoaded', () => {
     loadAutoUpdateConfig(); // New: Load auto-update config on page load
     loadActivePacks();
     addActivateButtonListeners();
+    addExportButtonListeners();
     addRenameButtonListeners();
     addBackupButtonListeners();
     addDeleteButtonListeners();

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -198,6 +198,9 @@
             <div id="restartNeededNote" class="info-box" style="display: none; background-color: #fff3cd; border: 1px solid #ffeeba; color: #856404; padding: 10px; margin-bottom: 15px; border-radius: 4px;">
                 <strong>Notice:</strong> Server properties have been updated. A restart is required for these changes to take effect.
             </div>
+            <div class="form-group" style="margin-bottom: 15px;">
+                <input type="text" id="propertySearch" placeholder="Search properties..." style="width: 100%;">
+            </div>
             <div class="tabs" id="propertiesTabs">
                 <!-- Tab buttons will be injected by JavaScript -->
             </div>


### PR DESCRIPTION
This PR introduces several user-facing enhancements to the Bedrock Server Manager:

1. **Backup & World Export**: Users can now download server backups (as .zip) and Minecraft worlds (as .mcworld) directly from the web interface. This improves portability and allows for easy sharing or external storage of server data.
2. **Improved Pack Management**: The active packs list now displays human-readable names parsed from `manifest.json` files, making it much easier to identify installed behavior and resource packs compared to the previous UUID-only display.
3. **Properties Search**: A real-time search bar has been added to the Server Properties section, allowing users to quickly filter through the many available configuration settings.

Technical improvements:
- Optimized pack name resolution logic by building a lookup map.
- Added safety checks to the properties search UI logic.
- Ensured unique filenames for exported ZIPs to prevent collisions.
- Verified functionality with the existing test suite (57/57 tests passing) and manual frontend verification.

---
*PR created automatically by Jules for task [18208682258832249977](https://jules.google.com/task/18208682258832249977) started by @brettfxio*