### PR TITLE
UI Enhancements, Robust Cleanup, and New Tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -285,14 +285,17 @@ app.get('/api/backups/:backupName/download', async (req, res) => {
         const { backupName } = req.params;
         const result = await backend.exportBackup(backupName);
         if (result.success) {
+            res.on('close', () => {
+                fs.promises.unlink(result.zipPath).catch(cleanupErr => {
+                    if (fs.existsSync(result.zipPath)) {
+                        backend.log('WARNING', `Failed to delete temporary backup ZIP ${result.zipPath}: ${cleanupErr.message}`);
+                    }
+                });
+            });
             res.download(result.zipPath, `${backupName}.zip`, (err) => {
-                if (err) {
+                if (err && !res.headersSent) {
                     backend.log('ERROR', `Error downloading backup ZIP: ${err.message}`);
                 }
-                // Cleanup temp file after download
-                fs.promises.unlink(result.zipPath).catch(cleanupErr => {
-                    backend.log('WARNING', `Failed to delete temporary backup ZIP ${result.zipPath}: ${cleanupErr.message}`);
-                });
             });
         } else {
             res.status(400).json(result);
@@ -446,14 +449,17 @@ app.get('/api/worlds/:worldName/export', async (req, res) => {
         const { worldName } = req.params;
         const result = await backend.exportWorld(worldName);
         if (result.success) {
+            res.on('close', () => {
+                fs.promises.unlink(result.zipPath).catch(cleanupErr => {
+                    if (fs.existsSync(result.zipPath)) {
+                        backend.log('WARNING', `Failed to delete temporary world export ${result.zipPath}: ${cleanupErr.message}`);
+                    }
+                });
+            });
             res.download(result.zipPath, `${worldName}.mcworld`, (err) => {
-                if (err) {
+                if (err && !res.headersSent) {
                     backend.log('ERROR', `Error downloading world export: ${err.message}`);
                 }
-                // Cleanup temp file after download
-                fs.promises.unlink(result.zipPath).catch(cleanupErr => {
-                    backend.log('WARNING', `Failed to delete temporary world export ${result.zipPath}: ${cleanupErr.message}`);
-                });
             });
         } else {
             res.status(400).json(result);

--- a/public/script.js
+++ b/public/script.js
@@ -8,6 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const backupButton = document.getElementById('backupButton');
     const clearLogsButton = document.getElementById('clearLogsButton');
     const downloadLogsButton = document.getElementById('downloadLogsButton');
+    const refreshBackupsButton = document.getElementById('refreshBackupsButton');
+    const refreshWorldsButton = document.getElementById('refreshWorldsButton');
     const propertiesForm = document.getElementById('propertiesForm');
     const propertiesContainer = document.getElementById('propertiesContainer');
     const propertiesTabs = document.getElementById('propertiesTabs');
@@ -812,6 +814,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     async function handleActivateWorldClick(event) {
         const worldName = event.target.dataset.worldName;
+        if (!confirm(`Are you sure you want to activate the world '${worldName}'? This will restart the server.`)) return;
+
         try {
             showMessage(`Activating world '${worldName}'...`);
             const response = await fetch('/api/activate-world', {
@@ -996,6 +1000,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     if (clearLogsButton) clearLogsButton.addEventListener('click', handleClearLogs);
+    if (refreshBackupsButton) refreshBackupsButton.addEventListener('click', loadBackups);
+    if (refreshWorldsButton) refreshWorldsButton.addEventListener('click', loadWorlds);
     if (createWorldForm) createWorldForm.addEventListener('submit', handleCreateWorld);
     if (uploadWorldForm) uploadWorldForm.addEventListener('submit', handleUploadWorld);
     if (downloadLogsButton) {

--- a/test/exports_and_uploads.test.js
+++ b/test/exports_and_uploads.test.js
@@ -1,0 +1,131 @@
+import { jest } from '@jest/globals';
+import * as path from 'path';
+
+// Mocking fs and adm-zip
+jest.unstable_mockModule('fs', () => ({
+    existsSync: jest.fn(),
+    mkdirSync: jest.fn(),
+    promises: {
+        readFile: jest.fn(),
+        writeFile: jest.fn(),
+        unlink: jest.fn(),
+        rm: jest.fn(),
+        readdir: jest.fn(),
+    },
+    readFileSync: jest.fn(),
+    writeFileSync: jest.fn(),
+    rmSync: jest.fn(),
+    createWriteStream: jest.fn(() => ({
+        write: jest.fn(),
+        end: jest.fn(),
+        on: jest.fn(),
+        pipe: jest.fn()
+    })),
+    readdirSync: jest.fn(),
+}));
+
+// Mock adm-zip
+const mockZipInstance = {
+    addLocalFolder: jest.fn(),
+    writeZip: jest.fn(),
+    getEntries: jest.fn(),
+    readAsText: jest.fn(),
+    extractAllTo: jest.fn(),
+};
+
+jest.unstable_mockModule('adm-zip', () => ({
+    default: jest.fn(() => mockZipInstance)
+}));
+
+// Dynamically import the modules
+const fs = await import('fs');
+const { default: AdmZip } = await import('adm-zip');
+const backend = await import('../minecraft_bedrock_installer_nodejs.js');
+
+describe('Exports and Uploads Tests', () => {
+    const mockConfig = {
+        serverDirectory: '/mock/server',
+        tempDirectory: '/mock/temp',
+        backupDirectory: '/mock/backup',
+        logLevel: 'ERROR'
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        backend.init(mockConfig);
+    });
+
+    describe('exportBackup', () => {
+        it('should successfully export a backup', async () => {
+            fs.existsSync.mockReturnValue(true);
+            const backupName = 'test-backup';
+
+            const result = await backend.exportBackup(backupName);
+
+            expect(result.success).toBe(true);
+            expect(result.zipPath).toContain('/mock/temp/backup-test-backup-');
+            expect(mockZipInstance.addLocalFolder).toHaveBeenCalledWith(path.join('/mock/backup', backupName));
+            expect(mockZipInstance.writeZip).toHaveBeenCalled();
+        });
+
+        it('should fail if backup does not exist', async () => {
+            fs.existsSync.mockReturnValue(false);
+            const result = await backend.exportBackup('non-existent');
+
+            expect(result.success).toBe(false);
+            expect(result.message).toBe('Backup not found.');
+        });
+    });
+
+    describe('exportWorld', () => {
+        it('should successfully export a world', async () => {
+            fs.existsSync.mockReturnValue(true);
+            const worldName = 'test-world';
+
+            const result = await backend.exportWorld(worldName);
+
+            expect(result.success).toBe(true);
+            expect(result.zipPath).toContain('/mock/temp/world-test-world-');
+            expect(mockZipInstance.addLocalFolder).toHaveBeenCalledWith(path.join('/mock/server', 'worlds', worldName));
+            expect(mockZipInstance.writeZip).toHaveBeenCalled();
+        });
+
+        it('should fail if world does not exist', async () => {
+            fs.existsSync.mockImplementation((p) => {
+                if (p.includes('worlds')) return false;
+                return true;
+            });
+            const result = await backend.exportWorld('non-existent');
+
+            expect(result.success).toBe(false);
+            expect(result.message).toBe('World not found.');
+        });
+    });
+
+    describe('uploadWorld', () => {
+        it('should successfully upload a world', async () => {
+            const tempFilePath = '/mock/temp/upload.mcworld';
+            const originalFilename = 'MyWorld.mcworld';
+
+            mockZipInstance.getEntries.mockReturnValue([
+                { entryName: 'world/level.dat', isDirectory: false, getData: jest.fn().mockReturnValue(Buffer.from('level data')) },
+                { entryName: 'world/levelname.txt', isDirectory: false, getData: jest.fn().mockReturnValue(Buffer.from('My Minecraft World')) }
+            ]);
+            mockZipInstance.readAsText.mockReturnValue('My Minecraft World');
+            fs.existsSync.mockReturnValue(false); // For collision check
+
+            const result = await backend.uploadWorld(tempFilePath, originalFilename);
+
+            expect(result.success).toBe(true);
+            expect(result.worldName).toBe('My Minecraft World');
+            expect(fs.mkdirSync).toHaveBeenCalledWith(path.join('/mock/server', 'worlds', 'My Minecraft World'), { recursive: true });
+        });
+
+        it('should fail if level.dat is missing', async () => {
+            mockZipInstance.getEntries.mockReturnValue([]);
+            const result = await backend.uploadWorld('/path', 'file.mcworld');
+            expect(result.success).toBe(false);
+            expect(result.message).toBe('Invalid world file: level.dat not found.');
+        });
+    });
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -84,7 +84,10 @@
         </div>
 
         <div class="section">
-            <h2>Backup Management</h2>
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+                <h2 style="margin: 0;">Backup Management</h2>
+                <button id="refreshBackupsButton" class="bg-gray-500 hover:bg-gray-700 text-white text-sm py-1 px-3 rounded transition duration-300" style="width: auto;">Refresh</button>
+            </div>
             <div id="backupList" class="world-list">
                 <p>Loading backups...</p>
             </div>
@@ -106,7 +109,10 @@
         </div>
 
         <div class="section">
-            <h2>World Management</h2>
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+                <h2 style="margin: 0;">World Management</h2>
+                <button id="refreshWorldsButton" class="bg-gray-500 hover:bg-gray-700 text-white text-sm py-1 px-3 rounded transition duration-300" style="width: auto;">Refresh</button>
+            </div>
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 20px;">
                 <form id="createWorldForm">
                     <div class="form-group">


### PR DESCRIPTION
This PR introduces several quality-of-life improvements and robustness fixes to the Bedrock Server Manager:

1. **UI Enhancements**: Added "Refresh" buttons to the Backup and World management sections, allowing users to update these lists without a full page reload. Added a safety confirmation dialog when activating a world, as this action triggers a server restart.
2. **Resource Cleanup**: Modified the export routes for worlds and backups to use the `res.on('close')` event for deleting temporary ZIP files. This ensures that even if a download is cancelled or interrupted, the server correctly cleans up the temporary artifacts.
3. **Increased Test Coverage**: Created `test/exports_and_uploads.test.js` to provide unit testing for the backend logic responsible for world and backup exports, as well as world uploads.

All tests passed successfully, and frontend changes were verified visually via Playwright.

---
*PR created automatically by Jules for task [10180106326946168218](https://jules.google.com/task/10180106326946168218) started by @brettfxio*